### PR TITLE
refactor: Introduce SearchQuery interface

### DIFF
--- a/src/main/java/it/mulders/mcs/search/Constants.java
+++ b/src/main/java/it/mulders/mcs/search/Constants.java
@@ -1,5 +1,5 @@
 package it.mulders.mcs.search;
 
 public class Constants {
-    public static final int MAX_SEARCH_RESULTS = 20;
+    public static final Integer DEFAULT_MAX_SEARCH_RESULTS = 20;
 }

--- a/src/main/java/it/mulders/mcs/search/CoordinateQuery.java
+++ b/src/main/java/it/mulders/mcs/search/CoordinateQuery.java
@@ -1,0 +1,38 @@
+package it.mulders.mcs.search;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import static it.mulders.mcs.search.Constants.DEFAULT_MAX_SEARCH_RESULTS;
+
+public record CoordinateQuery (
+        String groupId,
+        String artifactId,
+        String version,
+        Integer searchLimit
+) implements SearchQuery {
+    CoordinateQuery(final String groupId, final String artifactId) {
+        this(groupId, artifactId, null, DEFAULT_MAX_SEARCH_RESULTS);
+    }
+
+    CoordinateQuery(final String groupId, final String artifactId, final String version) {
+        this(groupId, artifactId, version, DEFAULT_MAX_SEARCH_RESULTS);
+    }
+
+    public SearchQuery withLimit(final Integer limit) {
+        return new CoordinateQuery(groupId, artifactId, version, limit);
+    }
+
+    @Override
+    public String toSolrQuery() {
+        String query;
+        if (version == null) {
+            query = String.format("g:%s AND a:%s", groupId, artifactId);
+        } else {
+            query = String.format("g:%s AND a:%s AND v:%s", groupId, artifactId, version);
+        }
+
+        return String.format("q=%s&start=%d&rows=%d",
+                URLEncoder.encode(query, StandardCharsets.UTF_8), 0, searchLimit());
+    }
+}

--- a/src/main/java/it/mulders/mcs/search/SearchClient.java
+++ b/src/main/java/it/mulders/mcs/search/SearchClient.java
@@ -5,12 +5,8 @@ import it.mulders.mcs.common.SearchResponseBodyHandler;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
-import java.nio.charset.StandardCharsets;
-
-import static it.mulders.mcs.search.Constants.MAX_SEARCH_RESULTS;
 
 public class SearchClient {
     private final String hostname;
@@ -25,50 +21,8 @@ public class SearchClient {
         this.hostname = hostname;
     }
 
-    /**
-     * Perform a "wildcard" search - that is, a search where the user does not specify
-     * if the value they're looking for is a <code>groupId</code> or an <code>artifactId</code>.
-     * Fetches at most 20 items.
-     *
-     * @param query The value to search for.
-     * @return Either a {@link SearchResponse} instance or a {@link Throwable}.
-     */
-    public Result<SearchResponse> wildcardSearch(final String query) {
-        return performSearch(query);
-    }
-
-    /**
-     * Perform a "specific" search - that is, a search where the user specifies
-     * the <code>groupId</code> and <code>artifactId</code>, separated by <code>:</code>.
-     * Fetches at most 20 items.
-     *
-     * @param groupId The groupId to search for.
-     * @param artifactId The artifactId to search for.
-     * @return Either a {@link SearchResponse} instance or a {@link Throwable}.
-     */
-    public Result<SearchResponse> singularSearch(final String groupId, final String artifactId) {
-        var query = String.format("g:%s AND a:%s", groupId, artifactId);
-        return performSearch(query);
-    }
-
-    /**
-     * Perform a "specific" search - that is, a search where the user specifies
-     * the <code>groupId</code>, <code>artifactId</code> and  <code>version</code>, separated by <code>:</code>.
-     * Fetches at most 20 items.
-     *
-     * @param groupId The groupId to search for.
-     * @param artifactId The artifactId to search for.
-     * @param version The version to search for.
-     * @return Either a {@link SearchResponse} instance or a {@link Throwable}.
-     */
-    public Result<SearchResponse> singularSearch(final String groupId, final String artifactId, final String version) {
-        var query = String.format("g:%s AND a:%s AND v:%s", groupId, artifactId, version);
-        return performSearch(query);
-    }
-
-    private Result<SearchResponse> performSearch(final String query) {
-        var uri = String.format("%s/solrsearch/select?q=%s&start=0&rows=%d",
-                hostname, URLEncoder.encode(query, StandardCharsets.UTF_8), MAX_SEARCH_RESULTS);
+    public Result<SearchResponse> search(final SearchQuery query) {
+        var uri = String.format("%s/solrsearch/select?%s", hostname, query.toSolrQuery());
 
         var request = HttpRequest.newBuilder()
                 .uri(URI.create(uri))

--- a/src/main/java/it/mulders/mcs/search/SearchCommandHandler.java
+++ b/src/main/java/it/mulders/mcs/search/SearchCommandHandler.java
@@ -14,52 +14,17 @@ public class SearchCommandHandler {
         this.outputPrinter = outputPrinter;
     }
 
-    public void search(final String query) {
-        System.out.printf("Searching for %s...%n", query);
+    public void search(final String input) {
+        System.out.printf("Searching for %s...%n", input);
 
-        if (isCoordinateSearch(query)) {
-            performCoordinateSearch(query);
-        } else {
-            performWildcardSearch(query);
-        }
-    }
+        var query = SearchQuery.fromUserInput(input);
 
-    private void performWildcardSearch(final String query) {
-        searchClient.wildcardSearch(query)
+        searchClient.search(query)
                 .map(SearchResponse::response)
                 .ifPresent(this::printResponse);
     }
 
-    private void performCoordinateSearch(final String query) {
-        var parts = query.split(":");
-        if (parts.length < 2 || parts.length > 3) {
-            var msg = """
-                        Searching a particular artifact requires at least groupId:artifactId and optionally :version
-                        """;
-            throw new IllegalArgumentException(msg);
-        }
-
-        var groupId = parts[0];
-        var artifactId = parts[1];
-        var hasVersion = parts.length == 3;
-        if (hasVersion) {
-            var version = parts[2];
-
-            searchClient.singularSearch(groupId, artifactId, version)
-                    .map(SearchResponse::response)
-                    .ifPresent(this::printResponse);
-        } else {
-            searchClient.singularSearch(groupId, artifactId)
-                    .map(SearchResponse::response)
-                    .ifPresent(this::printResponse);
-        }
-    }
-
     private void printResponse(final SearchResponse.Response response) {
         outputPrinter.print(response, System.out);
-    }
-
-    private boolean isCoordinateSearch(final String query) {
-        return query.contains(":");
     }
 }

--- a/src/main/java/it/mulders/mcs/search/SearchQuery.java
+++ b/src/main/java/it/mulders/mcs/search/SearchQuery.java
@@ -1,0 +1,35 @@
+package it.mulders.mcs.search;
+
+public sealed interface SearchQuery permits CoordinateQuery, WildcardSearchQuery {
+    Integer searchLimit();
+
+    String toSolrQuery();
+
+    static SearchQuery fromUserInput(final String input) {
+        if (isCoordinateSearch(input)) {
+            var parts = input.split(":");
+            if (parts.length < 2 || parts.length > 3) {
+                var msg = """
+                        Searching a particular artifact requires at least groupId:artifactId and optionally :version
+                        """;
+                throw new IllegalArgumentException(msg);
+            }
+
+            var groupId = parts[0];
+            var artifactId = parts[1];
+            var hasVersion = parts.length == 3;
+            if (hasVersion) {
+                var version = parts[2];
+                return new CoordinateQuery(groupId, artifactId, version);
+            } else {
+                return new CoordinateQuery(groupId, artifactId);
+            }
+        } else {
+            return new WildcardSearchQuery(input);
+        }
+    }
+
+    private static boolean isCoordinateSearch(final String query) {
+        return query.contains(":");
+    }
+}

--- a/src/main/java/it/mulders/mcs/search/TabularOutputPrinter.java
+++ b/src/main/java/it/mulders/mcs/search/TabularOutputPrinter.java
@@ -12,7 +12,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static it.mulders.mcs.search.Constants.MAX_SEARCH_RESULTS;
+import static it.mulders.mcs.search.Constants.DEFAULT_MAX_SEARCH_RESULTS;
 
 public class TabularOutputPrinter implements OutputPrinter {
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(
@@ -24,8 +24,8 @@ public class TabularOutputPrinter implements OutputPrinter {
 
     private String header(final SearchResponse.Response response) {
         var numFound = response.numFound();
-        var additionalMessage = numFound > MAX_SEARCH_RESULTS
-                ? String.format(" (showing first %d)", MAX_SEARCH_RESULTS)
+        var additionalMessage = numFound > DEFAULT_MAX_SEARCH_RESULTS
+                ? String.format(" (showing first %d)", DEFAULT_MAX_SEARCH_RESULTS)
                 : "";
         return String.format("Found @|bold %d|@ results%s%n",
                 response.numFound(), additionalMessage);

--- a/src/main/java/it/mulders/mcs/search/WildcardSearchQuery.java
+++ b/src/main/java/it/mulders/mcs/search/WildcardSearchQuery.java
@@ -1,0 +1,21 @@
+package it.mulders.mcs.search;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import static it.mulders.mcs.search.Constants.DEFAULT_MAX_SEARCH_RESULTS;
+
+public record WildcardSearchQuery(
+        String term,
+        Integer searchLimit
+) implements SearchQuery {
+    WildcardSearchQuery(final String term) {
+        this(term, DEFAULT_MAX_SEARCH_RESULTS);
+    }
+
+    @Override
+    public String toSolrQuery() {
+        return String.format("q=%s&start=%d&rows=%d",
+                URLEncoder.encode(term, StandardCharsets.UTF_8), 0, searchLimit());
+    }
+}

--- a/src/test/java/it/mulders/mcs/search/SearchClientIT.java
+++ b/src/test/java/it/mulders/mcs/search/SearchClientIT.java
@@ -45,7 +45,7 @@ class SearchClientIT implements WithAssertions {
 
             // Act
             var result = new SearchClient(wmRuntimeInfo.getHttpBaseUrl())
-                    .wildcardSearch("plexus-utils");
+                    .search(new WildcardSearchQuery("plexus-utils"));
 
             // Assert
             assertThat(result.value()).isNotNull();
@@ -69,7 +69,7 @@ class SearchClientIT implements WithAssertions {
 
             // Act
             var result = new SearchClient(wmRuntimeInfo.getHttpBaseUrl())
-                    .singularSearch("org.codehaus.plexus", "plexus-utils");
+                    .search(new CoordinateQuery("org.codehaus.plexus", "plexus-utils"));
 
             // Assert
             assertThat(result.value()).isNotNull();
@@ -89,7 +89,7 @@ class SearchClientIT implements WithAssertions {
 
             // Act
             var result = new SearchClient(wmRuntimeInfo.getHttpBaseUrl())
-                    .singularSearch("org.codehaus.plexus", "plexus-utils", "3.4.1");
+                    .search(new CoordinateQuery("org.codehaus.plexus", "plexus-utils", "3.4.1"));
 
             // Assert
             assertThat(result.value()).isNotNull();
@@ -109,7 +109,7 @@ class SearchClientIT implements WithAssertions {
         void should_gracefully_return_failures(final WireMockRuntimeInfo wmRuntimeInfo) throws MalformedURLException {
             // Very unlikely there's an HTTP server running there...
             var result = new SearchClient("http://localhost:21")
-                    .wildcardSearch("plexus-utils");
+                    .search(new WildcardSearchQuery("plexus-utils"));
 
             assertThat(result).isInstanceOf(Result.Failure.class);
             assertThat(result.cause()).isInstanceOf(ConnectException.class);

--- a/src/test/java/it/mulders/mcs/search/SearchCommandHandlerTest.java
+++ b/src/test/java/it/mulders/mcs/search/SearchCommandHandlerTest.java
@@ -33,18 +33,14 @@ class SearchCommandHandlerTest implements WithAssertions {
     );
     private final SearchClient searchClient = new SearchClient() {
         @Override
-        public Result<SearchResponse> wildcardSearch(String query) {
-            return new Result.Success<>(new SearchResponse(null, wildcardResponse));
-        }
-
-        @Override
-        public Result<SearchResponse> singularSearch(String groupId, String artifactId) {
-            return new Result.Success<>(new SearchResponse(null, twoPartCoordinateResponse));
-        }
-
-        @Override
-        public Result<SearchResponse> singularSearch(String groupId, String artifactId, String version) {
-            return new Result.Success<>(new SearchResponse(null, threePartCoordinateResponse));
+        public Result<SearchResponse> search(final SearchQuery query) {
+            if (query instanceof WildcardSearchQuery) {
+                return new Result.Success<>(new SearchResponse(null, wildcardResponse));
+            } else if (query instanceof CoordinateQuery cq && cq.version() == null) {
+                return new Result.Success<>(new SearchResponse(null, twoPartCoordinateResponse));
+            } else {
+                return new Result.Success<>(new SearchResponse(null, threePartCoordinateResponse));
+            }
         }
     };
 


### PR DESCRIPTION
Applying the Command Object pattern will make future extensions to the Search command easier to implement.