### PR TITLE
fix: Hide 'showing x' message when number of results is less than (or equal to) the search limit

### DIFF
--- a/src/main/java/it/mulders/mcs/search/TabularOutputPrinter.java
+++ b/src/main/java/it/mulders/mcs/search/TabularOutputPrinter.java
@@ -22,7 +22,7 @@ public class TabularOutputPrinter implements OutputPrinter {
 
     private String header(final SearchQuery query, final SearchResponse.Response response) {
         var numFound = response.numFound();
-        var additionalMessage = numFound != query.searchLimit()
+        var additionalMessage = numFound > query.searchLimit()
                 ? String.format(" (showing %d)", response.docs().length)
                 : "";
         return String.format("Found @|bold %d|@ results%s%n",

--- a/src/test/java/it/mulders/mcs/search/TabularOutputPrinterTest.java
+++ b/src/test/java/it/mulders/mcs/search/TabularOutputPrinterTest.java
@@ -97,7 +97,79 @@ class TabularOutputPrinterTest implements WithAssertions {
     }
 
     @Test
-    void should_mention_when_number_of_results_differs_from_requested() {
+    void should_mention_when_number_of_results_is_larger_than_the_search_limit() {
+        // Arrange
+        var response = new SearchResponse.Response(4, 0, new SearchResponse.Response.Doc[] {
+                new SearchResponse.Response.Doc(
+                        "org.codehaus.plexus:plexus-utils",
+                        "org.codehaus.plexus",
+                        "plexus-utils",
+                        null,
+                        "3.4.1",
+                        "jar",
+                        1630022910000L
+                ),
+                new SearchResponse.Response.Doc(
+                        "org.codehaus.plexus:plexus-archiver",
+                        "org.codehaus.plexus",
+                        "plexus-archiver",
+                        null,
+                        "4.2.7",
+                        "jar",
+                        1630022910000L
+                )
+        });
+        var buffer = new ByteArrayOutputStream();
+
+
+        // Act
+        var query = SearchQuery.search("org.codehaus.plexus:plexus-utils").withLimit(2).build();
+        output.print(query, response, new PrintStream(buffer));
+
+
+        // Assert
+        var table = buffer.toString();
+        assertThat(table).contains("showing 2");
+    }
+
+    @Test
+    void should_not_mention_when_number_of_results_is_equal_to_the_search_limit() {
+        // Arrange
+        var response = new SearchResponse.Response(2, 0, new SearchResponse.Response.Doc[] {
+                new SearchResponse.Response.Doc(
+                        "org.codehaus.plexus:plexus-utils",
+                        "org.codehaus.plexus",
+                        "plexus-utils",
+                        null,
+                        "3.4.1",
+                        "jar",
+                        1630022910000L
+                ),
+                new SearchResponse.Response.Doc(
+                        "org.codehaus.plexus:plexus-archiver",
+                        "org.codehaus.plexus",
+                        "plexus-archiver",
+                        null,
+                        "4.2.7",
+                        "jar",
+                        1630022910000L
+                )
+        });
+        var buffer = new ByteArrayOutputStream();
+
+
+        // Act
+        var query = SearchQuery.search("org.codehaus.plexus:plexus-utils").withLimit(2).build();
+        output.print(query, response, new PrintStream(buffer));
+
+
+        // Assert
+        var table = buffer.toString();
+        assertThat(table).doesNotContain("showing 1");
+    }
+
+    @Test
+    void should_not_mention_when_number_of_results_is_smaller_than_the_search_limit() {
         // Arrange
         var response = new SearchResponse.Response(1, 0, new SearchResponse.Response.Doc[] {
                 new SearchResponse.Response.Doc(
@@ -114,12 +186,12 @@ class TabularOutputPrinterTest implements WithAssertions {
 
 
         // Act
-        var query = SearchQuery.search("org.codehaus.plexus:plexus-utils").withLimit(5).build();
+        var query = SearchQuery.search("org.codehaus.plexus:plexus-utils").withLimit(2).build();
         output.print(query, response, new PrintStream(buffer));
 
 
         // Assert
         var table = buffer.toString();
-        assertThat(table).contains("showing 1");
+        assertThat(table).doesNotContain("showing 1");
     }
 }


### PR DESCRIPTION
Closes #47