### PR TITLE
fix: Search with limit above Sonatype maximum

### DIFF
--- a/src/main/java/it/mulders/mcs/search/ClassnameQuery.java
+++ b/src/main/java/it/mulders/mcs/search/ClassnameQuery.java
@@ -4,26 +4,37 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
 import static it.mulders.mcs.search.Constants.DEFAULT_MAX_SEARCH_RESULTS;
+import static it.mulders.mcs.search.Constants.DEFAULT_START;
 
 public record ClassnameQuery(
         String query,
         boolean fullyQualified,
-        int searchLimit
+        int searchLimit,
+        int start
 ) implements SearchQuery {
     @Override
     public String toSolrQuery() {
         if (fullyQualified) {
             return String.format("q=fc:%s&start=%d&rows=%d",
-                    URLEncoder.encode(query, StandardCharsets.UTF_8), 0, searchLimit());
+                    URLEncoder.encode(query, StandardCharsets.UTF_8), start(), searchLimit());
         } else {
             return String.format("q=c:%s&start=%d&rows=%d",
-                    URLEncoder.encode(query, StandardCharsets.UTF_8), 0, searchLimit());
+                    URLEncoder.encode(query, StandardCharsets.UTF_8), start(), searchLimit());
         }
+    }
+
+    @Override
+    public ClassnameQuery.Builder toBuilder() {
+        return new ClassnameQuery.Builder(query())
+                .isFullyQualified(fullyQualified())
+                .withLimit(searchLimit())
+                .withStart(start());
     }
 
     public static class Builder implements SearchQuery.Builder {
         private String query;
         private Integer limit = DEFAULT_MAX_SEARCH_RESULTS;
+        private Integer start = DEFAULT_START;
         private boolean fullyQualified = false;
 
         public Builder(String query) {
@@ -32,6 +43,14 @@ public record ClassnameQuery(
 
         public Builder isFullyQualified(boolean isFullyQualified) {
             this.fullyQualified = isFullyQualified;
+            return this;
+        }
+
+        @Override
+        public Builder withStart(Integer start) {
+            if (this.start != null) {
+                this.start = start;
+            }
             return this;
         }
 
@@ -45,7 +64,7 @@ public record ClassnameQuery(
 
         @Override
         public SearchQuery build() {
-            return new ClassnameQuery(query, fullyQualified, limit);
+            return new ClassnameQuery(query, fullyQualified, limit, start);
         }
     }
 

--- a/src/main/java/it/mulders/mcs/search/Constants.java
+++ b/src/main/java/it/mulders/mcs/search/Constants.java
@@ -2,4 +2,6 @@ package it.mulders.mcs.search;
 
 public class Constants {
     public static final Integer DEFAULT_MAX_SEARCH_RESULTS = 20;
+    public static final Integer DEFAULT_START = 0;
+    public static final Integer MAX_LIMIT = 200;
 }

--- a/src/main/java/it/mulders/mcs/search/CoordinateQuery.java
+++ b/src/main/java/it/mulders/mcs/search/CoordinateQuery.java
@@ -6,12 +6,14 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static it.mulders.mcs.search.Constants.DEFAULT_MAX_SEARCH_RESULTS;
+import static it.mulders.mcs.search.Constants.DEFAULT_START;
 
 public record CoordinateQuery (
         String groupId,
         String artifactId,
         String version,
-        int searchLimit
+        int searchLimit,
+        int start
 ) implements SearchQuery {
     @Override
     public String toSolrQuery() {
@@ -22,7 +24,14 @@ public record CoordinateQuery (
         var query = String.join(" AND ", parts);
 
         return String.format("q=%s&core=gav&start=%d&rows=%d",
-                URLEncoder.encode(query, StandardCharsets.UTF_8), 0, searchLimit());
+                URLEncoder.encode(query, StandardCharsets.UTF_8), start(), searchLimit());
+    }
+
+    @Override
+    public CoordinateQuery.Builder toBuilder() {
+        return new CoordinateQuery.Builder(groupId(), artifactId(), version())
+                .withLimit(searchLimit())
+                .withStart(start());
     }
 
     public static class Builder implements SearchQuery.Builder {
@@ -30,6 +39,7 @@ public record CoordinateQuery (
         private String artifactId;
         private String version;
         private Integer limit = DEFAULT_MAX_SEARCH_RESULTS;
+        private Integer start = DEFAULT_START;
 
         public Builder(String groupId, String artifactId) {
             this(groupId, artifactId, null);
@@ -47,6 +57,14 @@ public record CoordinateQuery (
         }
 
         @Override
+        public Builder withStart(Integer start) {
+            if (this.start != null) {
+                this.start = start;
+            }
+            return this;
+        }
+
+        @Override
         public Builder withLimit(Integer limit) {
             if (limit != null) {
                 this.limit = limit;
@@ -56,7 +74,7 @@ public record CoordinateQuery (
 
         @Override
         public SearchQuery build() {
-            return new CoordinateQuery(groupId, artifactId, version, limit);
+            return new CoordinateQuery(groupId, artifactId, version, limit, start);
         }
     }
 }

--- a/src/main/java/it/mulders/mcs/search/SearchCommandHandler.java
+++ b/src/main/java/it/mulders/mcs/search/SearchCommandHandler.java
@@ -27,7 +27,9 @@ public class SearchCommandHandler {
     private SearchResponse.Response performAdditionalSearch(final SearchQuery query,
                                                             final SearchResponse.Response previousResponse) {
         var lastItemFoundIndex = previousResponse.docs().length;
-        if (lastItemFoundIndex >= query.searchLimit() || lastItemFoundIndex == previousResponse.numFound()) {
+        var enoughItemsForUserLimit = lastItemFoundIndex >= query.searchLimit();
+        var allItemsReceived = lastItemFoundIndex == previousResponse.numFound();
+        if (enoughItemsForUserLimit || allItemsReceived) {
             return previousResponse;
         }
         var remainingItems = query.searchLimit() - lastItemFoundIndex;

--- a/src/main/java/it/mulders/mcs/search/SearchCommandHandler.java
+++ b/src/main/java/it/mulders/mcs/search/SearchCommandHandler.java
@@ -1,5 +1,9 @@
 package it.mulders.mcs.search;
 
+import it.mulders.mcs.common.Result;
+
+import static it.mulders.mcs.search.Constants.MAX_LIMIT;
+
 public class SearchCommandHandler {
     private final SearchClient searchClient;
     private final OutputPrinter outputPrinter;
@@ -15,9 +19,41 @@ public class SearchCommandHandler {
     }
 
     public void search(final SearchQuery query) {
-        searchClient.search(query)
-                .map(SearchResponse::response)
+        performSearch(query)
+                .map(response -> performAdditionalSearch(query, response))
                 .ifPresent(response -> printResponse(query, response));
+    }
+
+    private SearchResponse.Response performAdditionalSearch(final SearchQuery query,
+                                                            final SearchResponse.Response previousResponse) {
+        var lastItemFoundIndex = previousResponse.docs().length;
+        if (lastItemFoundIndex >= query.searchLimit() || lastItemFoundIndex == previousResponse.numFound()) {
+            return previousResponse;
+        }
+        var remainingItems = query.searchLimit() - lastItemFoundIndex;
+        var remainingLimit = Math.min(remainingItems, MAX_LIMIT);
+        var updatedQuery = query.toBuilder().withStart(lastItemFoundIndex).withLimit(remainingLimit).build();
+
+        return performSearch(updatedQuery)
+                .map(response -> combineResponses(previousResponse, response))
+                .map(response -> performAdditionalSearch(query, response))
+                .value();
+    }
+
+    private SearchResponse.Response combineResponses(SearchResponse.Response response1, SearchResponse.Response response2) {
+        var docs = new SearchResponse.Response.Doc[response1.docs().length + response2.docs().length];
+        System.arraycopy(response1.docs(), 0, docs, 0, response1.docs().length);
+        System.arraycopy(response2.docs(), 0, docs, response1.docs().length, response2.docs().length);
+        return new SearchResponse.Response(
+                response1.numFound(),
+                response2.start(),
+                docs
+        );
+    }
+
+    private Result<SearchResponse.Response> performSearch(final SearchQuery query) {
+        return searchClient.search(query)
+                .map(SearchResponse::response);
     }
 
     private void printResponse(final SearchQuery query, final SearchResponse.Response response) {

--- a/src/main/java/it/mulders/mcs/search/SearchQuery.java
+++ b/src/main/java/it/mulders/mcs/search/SearchQuery.java
@@ -2,8 +2,10 @@ package it.mulders.mcs.search;
 
 public sealed interface SearchQuery permits CoordinateQuery, ClassnameQuery, WildcardSearchQuery {
     int searchLimit();
+    int start();
 
     String toSolrQuery();
+    Builder<?> toBuilder();
 
     static SearchQuery.Builder search(String query) {
         var isCoordinateSearch = query.contains(":");
@@ -28,8 +30,9 @@ public sealed interface SearchQuery permits CoordinateQuery, ClassnameQuery, Wil
         return new ClassnameQuery.Builder(query);
     }
 
-    interface Builder {
+    interface Builder<T extends SearchQuery> {
         <T extends Builder> T withLimit(final Integer limit);
+        <T extends Builder> T withStart(final Integer start);
         SearchQuery build();
     }
 }

--- a/src/main/java/it/mulders/mcs/search/WildcardSearchQuery.java
+++ b/src/main/java/it/mulders/mcs/search/WildcardSearchQuery.java
@@ -4,23 +4,41 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
 import static it.mulders.mcs.search.Constants.DEFAULT_MAX_SEARCH_RESULTS;
+import static it.mulders.mcs.search.Constants.DEFAULT_START;
 
 public record WildcardSearchQuery(
         String term,
-        int searchLimit
+        int searchLimit,
+        int start
 ) implements SearchQuery {
     @Override
     public String toSolrQuery() {
         return String.format("q=%s&start=%d&rows=%d",
-                URLEncoder.encode(term, StandardCharsets.UTF_8), 0, searchLimit());
+                URLEncoder.encode(term, StandardCharsets.UTF_8), start(), searchLimit());
+    }
+
+    @Override
+    public WildcardSearchQuery.Builder toBuilder() {
+        return new WildcardSearchQuery.Builder(term())
+                .withLimit(searchLimit())
+                .withStart(start());
     }
 
     public static class Builder implements SearchQuery.Builder {
         private String query;
         private Integer limit = DEFAULT_MAX_SEARCH_RESULTS;
+        private Integer start = DEFAULT_START;
 
         public Builder(String query) {
             this.query = query;
+        }
+
+        @Override
+        public Builder withStart(Integer start) {
+            if (this.start != null) {
+                this.start = start;
+            }
+            return this;
         }
 
         @Override
@@ -33,7 +51,7 @@ public record WildcardSearchQuery(
 
         @Override
         public SearchQuery build() {
-            return new WildcardSearchQuery(query, limit);
+            return new WildcardSearchQuery(query, limit, start);
         }
     }
 }

--- a/src/test/java/it/mulders/mcs/search/CoordinateQueryTest.java
+++ b/src/test/java/it/mulders/mcs/search/CoordinateQueryTest.java
@@ -15,7 +15,7 @@ class CoordinateQueryTest implements WithAssertions {
     class ToSolrQueryTest {
         @Test
         void solr_query_should_contain_groupId() {
-            var query = new CoordinateQuery("foo", "bar", "", Constants.DEFAULT_MAX_SEARCH_RESULTS);
+            var query = new CoordinateQuery("foo", "bar", "", Constants.DEFAULT_MAX_SEARCH_RESULTS, Constants.DEFAULT_START);
 
             var solrQuery = query.toSolrQuery();
 
@@ -24,7 +24,7 @@ class CoordinateQueryTest implements WithAssertions {
 
         @Test
         void solr_query_should_contain_artifactId() {
-            var query = new CoordinateQuery("foo", "bar", "", Constants.DEFAULT_MAX_SEARCH_RESULTS);
+            var query = new CoordinateQuery("foo", "bar", "", Constants.DEFAULT_MAX_SEARCH_RESULTS, Constants.DEFAULT_START);
 
             var solrQuery = query.toSolrQuery();
 
@@ -33,7 +33,7 @@ class CoordinateQueryTest implements WithAssertions {
 
         @Test
         void solr_query_should_contain_version() {
-            var query = new CoordinateQuery("foo", "bar", "1.0", Constants.DEFAULT_MAX_SEARCH_RESULTS);
+            var query = new CoordinateQuery("foo", "bar", "1.0", Constants.DEFAULT_MAX_SEARCH_RESULTS, Constants.DEFAULT_START);
 
             var solrQuery = query.toSolrQuery();
 
@@ -42,16 +42,16 @@ class CoordinateQueryTest implements WithAssertions {
 
         @Test
         void solr_query_should_contain_start() {
-            var query = new CoordinateQuery("foo", "bar", "", Constants.DEFAULT_MAX_SEARCH_RESULTS);
+            var query = new CoordinateQuery("foo", "bar", "", Constants.DEFAULT_MAX_SEARCH_RESULTS, 3);
 
             var solrQuery = query.toSolrQuery();
 
-            assertThat(solrQuery).contains("start=0");
+            assertThat(solrQuery).contains("start=3");
         }
 
         @Test
         void solr_query_should_contain_limit() {
-            var query = new CoordinateQuery("foo", "bar", "1.0", 5);
+            var query = new CoordinateQuery("foo", "bar", "1.0", 5, Constants.DEFAULT_START);
 
             var solrQuery = query.toSolrQuery();
 

--- a/src/test/java/it/mulders/mcs/search/SearchClientIT.java
+++ b/src/test/java/it/mulders/mcs/search/SearchClientIT.java
@@ -45,7 +45,7 @@ class SearchClientIT implements WithAssertions {
 
             // Act
             var result = new SearchClient(wmRuntimeInfo.getHttpBaseUrl())
-                    .search(new WildcardSearchQuery("plexus-utils", Constants.DEFAULT_MAX_SEARCH_RESULTS));
+                    .search(new WildcardSearchQuery("plexus-utils", Constants.DEFAULT_MAX_SEARCH_RESULTS, Constants.DEFAULT_START));
 
             // Assert
             assertThat(result.value()).isNotNull();
@@ -125,7 +125,7 @@ class SearchClientIT implements WithAssertions {
         void should_gracefully_handle_connection_failure(final WireMockRuntimeInfo wmRuntimeInfo) throws MalformedURLException {
             // Very unlikely there's an HTTP server running there...
             var result = new SearchClient("http://localhost:21")
-                    .search(new WildcardSearchQuery("plexus-utils", Constants.DEFAULT_MAX_SEARCH_RESULTS));
+                    .search(new WildcardSearchQuery("plexus-utils", Constants.DEFAULT_MAX_SEARCH_RESULTS, Constants.DEFAULT_START));
 
             assertThat(result).isInstanceOf(Result.Failure.class);
             assertThat(result.cause()).isInstanceOf(ConnectException.class);

--- a/src/test/java/it/mulders/mcs/search/WildcardSearchQueryTest.java
+++ b/src/test/java/it/mulders/mcs/search/WildcardSearchQueryTest.java
@@ -5,16 +5,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-
 class WildcardSearchQueryTest implements WithAssertions {
     @Nested
     @DisplayName("toSolrQuery")
     class ToSolrQueryTest {
         @Test
         void solr_query_should_contain_limit() {
-            var query = new WildcardSearchQuery("foo", 5);
+            var query = new WildcardSearchQuery("foo", 5, Constants.DEFAULT_START);
 
             var solrQuery = query.toSolrQuery();
 
@@ -23,7 +20,7 @@ class WildcardSearchQueryTest implements WithAssertions {
 
         @Test
         void solr_query_should_contain_search_term() {
-            var query = new WildcardSearchQuery("foo", Constants.DEFAULT_MAX_SEARCH_RESULTS);
+            var query = new WildcardSearchQuery("foo", Constants.DEFAULT_MAX_SEARCH_RESULTS, Constants.DEFAULT_START);
 
             var solrQuery = query.toSolrQuery();
 
@@ -32,11 +29,11 @@ class WildcardSearchQueryTest implements WithAssertions {
 
         @Test
         void solr_query_should_contain_start() {
-            var query = new WildcardSearchQuery("foo", Constants.DEFAULT_MAX_SEARCH_RESULTS);
+            var query = new WildcardSearchQuery("foo", Constants.DEFAULT_MAX_SEARCH_RESULTS, 3);
 
             var solrQuery = query.toSolrQuery();
 
-            assertThat(solrQuery).contains("start=0");
+            assertThat(solrQuery).contains("start=3");
         }
     }
 }


### PR DESCRIPTION
When the user asks for more than 200 items using `-l` or `--limit`, the Sonatype API would return only 20; the default row size. This leads to a confusing situation, as reported in #97: "I've asked for 3000, the output says there will be 1186 but I'm seeing only 20".