### PR TITLE
feat: Improve error response on mcs misuse

### DIFF
--- a/src/main/java/it/mulders/mcs/common/AbstractMcsException.java
+++ b/src/main/java/it/mulders/mcs/common/AbstractMcsException.java
@@ -1,0 +1,24 @@
+package it.mulders.mcs.common;
+
+public abstract class AbstractMcsException extends RuntimeException {
+
+    private final boolean suppressStacktrace;
+
+    protected AbstractMcsException(final String message) {
+        this(message, true);
+    }
+
+    private AbstractMcsException(final String message, final boolean suppressStacktrace) {
+        super(message, null, suppressStacktrace, !suppressStacktrace);
+        this.suppressStacktrace = suppressStacktrace;
+    }
+
+    @Override
+    public String toString() {
+        if (suppressStacktrace) {
+            return getLocalizedMessage();
+        } else {
+            return super.toString();
+        }
+    }
+}

--- a/src/main/java/it/mulders/mcs/common/IllegalResponseException.java
+++ b/src/main/java/it/mulders/mcs/common/IllegalResponseException.java
@@ -1,0 +1,8 @@
+package it.mulders.mcs.common;
+
+public class IllegalResponseException extends AbstractMcsException {
+
+    public IllegalResponseException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/it/mulders/mcs/common/NoRequestedElementException.java
+++ b/src/main/java/it/mulders/mcs/common/NoRequestedElementException.java
@@ -1,0 +1,8 @@
+package it.mulders.mcs.common;
+
+public class NoRequestedElementException extends AbstractMcsException {
+
+    public NoRequestedElementException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/it/mulders/mcs/common/Result.java
+++ b/src/main/java/it/mulders/mcs/common/Result.java
@@ -1,6 +1,5 @@
 package it.mulders.mcs.common;
 
-import java.util.NoSuchElementException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -22,7 +21,7 @@ public sealed interface Result<T> permits Result.Success, Result.Failure {
 
         @Override
         public Throwable cause() {
-            throw new NoSuchElementException("success: " + this.value);
+            throw new NoRequestedElementException("success: " + this.value);
         }
     }
 
@@ -38,7 +37,7 @@ public sealed interface Result<T> permits Result.Success, Result.Failure {
 
         @Override
         public T value() {
-            throw new NoSuchElementException("failure: " + this.cause.getLocalizedMessage());
+            throw new NoRequestedElementException("failure: " + this.cause.getLocalizedMessage());
         }
     }
 

--- a/src/main/java/it/mulders/mcs/common/SearchResponseBodyHandler.java
+++ b/src/main/java/it/mulders/mcs/common/SearchResponseBodyHandler.java
@@ -32,7 +32,7 @@ public class SearchResponseBodyHandler implements HttpResponse.BodyHandler<Resul
             return new Result.Success<>(constructSearchResponse(map));
         } catch (final JsonParseException | JSONObjectException joe) {
             return new Result.Failure<>(
-                    new IllegalStateException(
+                    new IllegalResponseException(
                             """
                             
                             Error parsing the search result. This may be a temporary failure from search.maven.org.
@@ -46,7 +46,7 @@ public class SearchResponseBodyHandler implements HttpResponse.BodyHandler<Resul
             );
         } catch (final IOException ioe) {
             return new Result.Failure<>(
-                    new IllegalStateException("Error processing response: %s%n".formatted(ioe.getLocalizedMessage()))
+                    new IllegalResponseException("Error processing response: %s%n".formatted(ioe.getLocalizedMessage()))
             );
         }
     }

--- a/src/main/java/it/mulders/mcs/search/IllegalQueryException.java
+++ b/src/main/java/it/mulders/mcs/search/IllegalQueryException.java
@@ -1,0 +1,10 @@
+package it.mulders.mcs.search;
+
+import it.mulders.mcs.common.AbstractMcsException;
+
+public class IllegalQueryException extends AbstractMcsException {
+
+    public IllegalQueryException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/it/mulders/mcs/search/SearchQuery.java
+++ b/src/main/java/it/mulders/mcs/search/SearchQuery.java
@@ -2,11 +2,9 @@ package it.mulders.mcs.search;
 
 public sealed interface SearchQuery permits CoordinateQuery, ClassnameQuery, WildcardSearchQuery {
     int searchLimit();
-
     int start();
 
     String toSolrQuery();
-
     Builder<? extends SearchQuery> toBuilder();
 
     static SearchQuery.Builder<? extends SearchQuery> search(String query) {
@@ -35,9 +33,7 @@ public sealed interface SearchQuery permits CoordinateQuery, ClassnameQuery, Wil
 
     interface Builder<T extends SearchQuery> {
         Builder<T> withLimit(final Integer limit);
-
         Builder<T> withStart(final Integer start);
-
         SearchQuery build();
     }
 }

--- a/src/main/java/it/mulders/mcs/search/SearchQuery.java
+++ b/src/main/java/it/mulders/mcs/search/SearchQuery.java
@@ -2,9 +2,11 @@ package it.mulders.mcs.search;
 
 public sealed interface SearchQuery permits CoordinateQuery, ClassnameQuery, WildcardSearchQuery {
     int searchLimit();
+
     int start();
 
     String toSolrQuery();
+
     Builder<? extends SearchQuery> toBuilder();
 
     static SearchQuery.Builder<? extends SearchQuery> search(String query) {
@@ -19,7 +21,7 @@ public sealed interface SearchQuery permits CoordinateQuery, ClassnameQuery, Wil
                     var msg = """
                             Searching a particular artifact requires at least groupId:artifactId and optionally :version
                             """;
-                    throw new IllegalArgumentException(msg);
+                    throw new IllegalQueryException(msg);
                 }
             };
         } else {
@@ -33,7 +35,9 @@ public sealed interface SearchQuery permits CoordinateQuery, ClassnameQuery, Wil
 
     interface Builder<T extends SearchQuery> {
         Builder<T> withLimit(final Integer limit);
+
         Builder<T> withStart(final Integer start);
+
         SearchQuery build();
     }
 }

--- a/src/main/java/it/mulders/mcs/search/UnsupportedFormatException.java
+++ b/src/main/java/it/mulders/mcs/search/UnsupportedFormatException.java
@@ -1,24 +1,10 @@
 package it.mulders.mcs.search;
 
-public class UnsupportedFormatException extends RuntimeException {
+import it.mulders.mcs.common.AbstractMcsException;
 
-    private final boolean suppressStacktrace;
+public class UnsupportedFormatException extends AbstractMcsException {
 
     public UnsupportedFormatException(final String message) {
-        this(message, true);
-    }
-
-    public UnsupportedFormatException(final String message, final boolean suppressStacktrace) {
-        super(message, null, suppressStacktrace, !suppressStacktrace);
-        this.suppressStacktrace = suppressStacktrace;
-    }
-
-    @Override
-    public String toString() {
-        if (suppressStacktrace) {
-            return getLocalizedMessage();
-        } else {
-            return super.toString();
-        }
+        super(message);
     }
 }

--- a/src/main/java/it/mulders/mcs/search/printer/CoordinatePrinter.java
+++ b/src/main/java/it/mulders/mcs/search/printer/CoordinatePrinter.java
@@ -14,7 +14,7 @@ public sealed interface CoordinatePrinter extends OutputPrinter
     @Override
     default void print(final SearchQuery query, final SearchResponse.Response response, final PrintStream stream) {
         if (response.numFound() != 1) {
-            throw new IllegalArgumentException("Search response with more than one result not expected here");
+            throw new UnexpectedResultException("Search response with more than one result not expected here");
         }
 
         var doc = response.docs()[0];

--- a/src/main/java/it/mulders/mcs/search/printer/NoOutputPrinter.java
+++ b/src/main/java/it/mulders/mcs/search/printer/NoOutputPrinter.java
@@ -9,7 +9,7 @@ public class NoOutputPrinter implements OutputPrinter {
     @Override
     public void print(final SearchQuery query, final SearchResponse.Response response, final PrintStream stream) {
         if (response.numFound() != 0) {
-            throw new IllegalArgumentException("Search response with any result not expected here");
+            throw new UnexpectedResultException("Search response with any result not expected here");
         }
 
         stream.println();

--- a/src/main/java/it/mulders/mcs/search/printer/TabularOutputPrinter.java
+++ b/src/main/java/it/mulders/mcs/search/printer/TabularOutputPrinter.java
@@ -53,7 +53,7 @@ public class TabularOutputPrinter implements OutputPrinter {
                 .map(SearchResponse.Response.Doc::id)
                 .mapToInt(String::length)
                 .max()
-                .orElseThrow(() -> new IllegalStateException("Used TabularOutputPrinter without any output"));
+                .orElseThrow(() -> new UnexpectedResultException("Used TabularOutputPrinter without any output"));
     }
 
     private void printRow(final Help.TextTable table, final SearchResponse.Response.Doc doc) {

--- a/src/main/java/it/mulders/mcs/search/printer/UnexpectedResultException.java
+++ b/src/main/java/it/mulders/mcs/search/printer/UnexpectedResultException.java
@@ -1,0 +1,10 @@
+package it.mulders.mcs.search.printer;
+
+import it.mulders.mcs.common.AbstractMcsException;
+
+public class UnexpectedResultException extends AbstractMcsException {
+
+    public UnexpectedResultException(final String message) {
+        super(message);
+    }
+}

--- a/src/test/java/it/mulders/mcs/common/ResultTest.java
+++ b/src/test/java/it/mulders/mcs/common/ResultTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicReference;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -47,10 +46,12 @@ class ResultTest implements WithAssertions {
             var input = new Result.Success<>("foo");
 
             // Act
-            var result = input.map(a -> { throw new NullPointerException(); });
+            var result = input.map(a -> {
+                throw new NullPointerException();
+            });
 
             // Assert
-            assertThatThrownBy(result::value).isInstanceOf(NoSuchElementException.class);
+            assertThatThrownBy(result::value).isInstanceOf(NoRequestedElementException.class);
             assertThat(result.cause()).isInstanceOf(NullPointerException.class);
         }
 
@@ -62,7 +63,7 @@ class ResultTest implements WithAssertions {
             // Act
 
             // Assert
-            assertThatThrownBy(input::cause).isInstanceOf(NoSuchElementException.class);
+            assertThatThrownBy(input::cause).isInstanceOf(NoRequestedElementException.class);
         }
     }
 
@@ -93,13 +94,14 @@ class ResultTest implements WithAssertions {
             var result = input.map(String::toUpperCase);
 
             // Assert
-            assertThatThrownBy(result::value).isInstanceOf(NoSuchElementException.class);
+            assertThatThrownBy(result::value).isInstanceOf(NoRequestedElementException.class);
         }
 
         @Test
         void cause() {
             // Arrange
-            var input = new Result.Failure<>(new Exception() {});
+            var input = new Result.Failure<>(new Exception() {
+            });
 
             // Act
 

--- a/src/test/java/it/mulders/mcs/common/ResultTest.java
+++ b/src/test/java/it/mulders/mcs/common/ResultTest.java
@@ -46,9 +46,7 @@ class ResultTest implements WithAssertions {
             var input = new Result.Success<>("foo");
 
             // Act
-            var result = input.map(a -> {
-                throw new NullPointerException();
-            });
+            var result = input.map(a -> { throw new NullPointerException(); });
 
             // Assert
             assertThatThrownBy(result::value).isInstanceOf(NoRequestedElementException.class);
@@ -100,8 +98,7 @@ class ResultTest implements WithAssertions {
         @Test
         void cause() {
             // Arrange
-            var input = new Result.Failure<>(new Exception() {
-            });
+            var input = new Result.Failure<>(new Exception() {});
 
             // Act
 

--- a/src/test/java/it/mulders/mcs/search/SearchClientIT.java
+++ b/src/test/java/it/mulders/mcs/search/SearchClientIT.java
@@ -2,6 +2,7 @@ package it.mulders.mcs.search;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import it.mulders.mcs.common.IllegalResponseException;
 import it.mulders.mcs.common.Result;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.DisplayName;
@@ -117,7 +118,7 @@ class SearchClientIT implements WithAssertions {
 
             // Assert
             assertThat(result).isInstanceOf(Result.Failure.class);
-            assertThat(result.cause()).isInstanceOf(IllegalStateException.class);
+            assertThat(result.cause()).isInstanceOf(IllegalResponseException.class);
             assertThat(result.cause()).hasMessageContaining("https://github.com/mthmulders/mcs/discussions");
         }
 

--- a/src/test/java/it/mulders/mcs/search/SearchCommandHandlerTest.java
+++ b/src/test/java/it/mulders/mcs/search/SearchCommandHandlerTest.java
@@ -3,16 +3,9 @@ package it.mulders.mcs.search;
 import it.mulders.mcs.common.Result;
 import it.mulders.mcs.search.printer.OutputPrinter;
 import org.assertj.core.api.WithAssertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class SearchCommandHandlerTest implements WithAssertions {
@@ -20,17 +13,17 @@ class SearchCommandHandlerTest implements WithAssertions {
     private final SearchResponse.Response wildcardResponse = new SearchResponse.Response(
             0,
             0,
-            new SearchResponse.Response.Doc[] {}
+            new SearchResponse.Response.Doc[]{}
     );
     private final SearchResponse.Response twoPartCoordinateResponse = new SearchResponse.Response(
             0,
             0,
-            new SearchResponse.Response.Doc[] {}
+            new SearchResponse.Response.Doc[]{}
     );
     private final SearchResponse.Response threePartCoordinateResponse = new SearchResponse.Response(
             0,
             0,
-            new SearchResponse.Response.Doc[] {}
+            new SearchResponse.Response.Doc[]{}
     );
     private final SearchClient searchClient = new SearchClient() {
         @Override
@@ -63,7 +56,7 @@ class SearchCommandHandlerTest implements WithAssertions {
         @Test
         void should_reject_search_terms_in_wrong_format() {
             assertThatThrownBy(() -> handler.search(SearchQuery.search("foo:bar:baz:qux").build()))
-                    .isInstanceOf(IllegalArgumentException.class);
+                    .isInstanceOf(IllegalQueryException.class);
         }
 
         @Test

--- a/src/test/java/it/mulders/mcs/search/SearchCommandHandlerTest.java
+++ b/src/test/java/it/mulders/mcs/search/SearchCommandHandlerTest.java
@@ -3,9 +3,16 @@ package it.mulders.mcs.search;
 import it.mulders.mcs.common.Result;
 import it.mulders.mcs.search.printer.OutputPrinter;
 import org.assertj.core.api.WithAssertions;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class SearchCommandHandlerTest implements WithAssertions {
@@ -13,17 +20,17 @@ class SearchCommandHandlerTest implements WithAssertions {
     private final SearchResponse.Response wildcardResponse = new SearchResponse.Response(
             0,
             0,
-            new SearchResponse.Response.Doc[]{}
+            new SearchResponse.Response.Doc[] {}
     );
     private final SearchResponse.Response twoPartCoordinateResponse = new SearchResponse.Response(
             0,
             0,
-            new SearchResponse.Response.Doc[]{}
+            new SearchResponse.Response.Doc[] {}
     );
     private final SearchResponse.Response threePartCoordinateResponse = new SearchResponse.Response(
             0,
             0,
-            new SearchResponse.Response.Doc[]{}
+            new SearchResponse.Response.Doc[] {}
     );
     private final SearchClient searchClient = new SearchClient() {
         @Override

--- a/src/test/java/it/mulders/mcs/search/printer/NoOutputPrinterTest.java
+++ b/src/test/java/it/mulders/mcs/search/printer/NoOutputPrinterTest.java
@@ -3,6 +3,8 @@ package it.mulders.mcs.search.printer;
 import it.mulders.mcs.search.SearchResponse;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -13,12 +15,11 @@ class NoOutputPrinterTest implements WithAssertions {
 
     private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-    @Test
-    void should_fail_with_non_empty_result() {
-        assertThatThrownBy(() -> printer.print(null, responseWithResult(1), new PrintStream(outputStream)))
-                .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> printer.print(null, responseWithResult(2), new PrintStream(outputStream)))
-                .isInstanceOf(IllegalArgumentException.class);
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2})
+    void should_fail_with_non_empty_result(int count) {
+        assertThatThrownBy(() -> printer.print(null, responseWithResult(count), new PrintStream(outputStream)))
+                .isInstanceOf(UnexpectedResultException.class);
     }
 
     @Test


### PR DESCRIPTION
Hello @mthmulders,
I would like to ask you for review of this PR, which presents solution proposal for #157.

Proposed solution turns current error responses, with exposed stack trace, e.g.:
![current exception](https://user-images.githubusercontent.com/57846939/215210788-aee6ab5e-9d10-4464-be88-1ceac4e08891.png)

into error responses with suppressed stack trace showing, e.g.:
![proposed exception](https://user-images.githubusercontent.com/57846939/215210867-9d2ce598-12a1-48d7-8340-2fb51c3fa85a.png)

Thank you in advance.

Best regards
@beo1975 