### PR TITLE
fix: Leverage PicoCLI error handling

### DIFF
--- a/src/main/java/it/mulders/mcs/App.java
+++ b/src/main/java/it/mulders/mcs/App.java
@@ -3,8 +3,14 @@ package it.mulders.mcs;
 import it.mulders.mcs.cli.Cli;
 import it.mulders.mcs.cli.CommandClassFactory;
 import picocli.CommandLine;
+import picocli.CommandLine.IExecutionExceptionHandler;
 
 public class App {
+    private static final IExecutionExceptionHandler executionExceptionHandler = (ex, commandLine, parseResult) -> {
+        System.err.println(ex.getLocalizedMessage());
+        return -1;
+    };
+
     public static void main(final String... args) {
         System.exit(doMain(args));
     }
@@ -12,7 +18,8 @@ public class App {
     // Visible for testing
     static int doMain(final String... args) {
         var cli = new Cli();
-        var program = new CommandLine(cli, new CommandClassFactory(cli));
+        var program = new CommandLine(cli, new CommandClassFactory(cli))
+                .setExecutionExceptionHandler(executionExceptionHandler);
         return program.execute(args);
     }
 }

--- a/src/main/java/it/mulders/mcs/search/UnsupportedFormatException.java
+++ b/src/main/java/it/mulders/mcs/search/UnsupportedFormatException.java
@@ -1,24 +1,7 @@
 package it.mulders.mcs.search;
 
 public class UnsupportedFormatException extends RuntimeException {
-
-    private final boolean suppressStacktrace;
-
     public UnsupportedFormatException(final String message) {
-        this(message, true);
-    }
-
-    public UnsupportedFormatException(final String message, final boolean suppressStacktrace) {
-        super(message, null, suppressStacktrace, !suppressStacktrace);
-        this.suppressStacktrace = suppressStacktrace;
-    }
-
-    @Override
-    public String toString() {
-        if (suppressStacktrace) {
-            return getLocalizedMessage();
-        } else {
-            return super.toString();
-        }
+        super(message);
     }
 }


### PR DESCRIPTION
This hides stack traces, which are an implementation detail and should not be presented to the end user.