### PR TITLE
Display plugin POM element for maven-plugins

### DIFF
--- a/src/main/java/it/mulders/mcs/search/printer/BuildrOutput.java
+++ b/src/main/java/it/mulders/mcs/search/printer/BuildrOutput.java
@@ -3,7 +3,7 @@ package it.mulders.mcs.search.printer;
 public final class BuildrOutput implements CoordinatePrinter {
 
     @Override
-    public String provideCoordinates(final String group, final String artifact, final String version) {
+    public String provideCoordinates(final String group, final String artifact, final String version, String packaging) {
         return "'%s:%s:jar:%s'".formatted(group, artifact, version);
     }
 }

--- a/src/main/java/it/mulders/mcs/search/printer/CoordinatePrinter.java
+++ b/src/main/java/it/mulders/mcs/search/printer/CoordinatePrinter.java
@@ -9,7 +9,7 @@ public sealed interface CoordinatePrinter extends OutputPrinter
         permits BuildrOutput, GradleGroovyOutput, GradleGroovyShortOutput, GradleKotlinOutput, GrapeOutput,
         IvyXmlOutput, LeiningenOutput, PomXmlOutput, SbtOutput {
 
-    String provideCoordinates(final String group, final String artifact, final String version);
+    String provideCoordinates(final String group, final String artifact, final String version, final String packaging);
 
     @Override
     default void print(final SearchQuery query, final SearchResponse.Response response, final PrintStream stream) {
@@ -19,7 +19,7 @@ public sealed interface CoordinatePrinter extends OutputPrinter
 
         var doc = response.docs()[0];
         stream.println();
-        stream.println(provideCoordinates(doc.g(), doc.a(), first(doc.v(), doc.latestVersion())));
+        stream.println(provideCoordinates(doc.g(), doc.a(), first(doc.v(), doc.latestVersion()), doc.p()));
         stream.println();
     }
 

--- a/src/main/java/it/mulders/mcs/search/printer/GradleGroovyOutput.java
+++ b/src/main/java/it/mulders/mcs/search/printer/GradleGroovyOutput.java
@@ -3,7 +3,7 @@ package it.mulders.mcs.search.printer;
 public final class GradleGroovyOutput implements CoordinatePrinter {
 
     @Override
-    public String provideCoordinates(final String group, final String artifact, final String version) {
+    public String provideCoordinates(final String group, final String artifact, final String version, String packaging) {
         return "implementation group: '%s', name: '%s', version: '%s'".formatted(group, artifact, version);
     }
 }

--- a/src/main/java/it/mulders/mcs/search/printer/GradleGroovyShortOutput.java
+++ b/src/main/java/it/mulders/mcs/search/printer/GradleGroovyShortOutput.java
@@ -3,7 +3,7 @@ package it.mulders.mcs.search.printer;
 public final class GradleGroovyShortOutput implements CoordinatePrinter {
 
     @Override
-    public String provideCoordinates(final String group, final String artifact, final String version) {
+    public String provideCoordinates(final String group, final String artifact, final String version, String packaging) {
         return "implementation '%s:%s:%s'".formatted(group, artifact, version);
     }
 }

--- a/src/main/java/it/mulders/mcs/search/printer/GradleKotlinOutput.java
+++ b/src/main/java/it/mulders/mcs/search/printer/GradleKotlinOutput.java
@@ -3,7 +3,7 @@ package it.mulders.mcs.search.printer;
 public final class GradleKotlinOutput implements CoordinatePrinter {
 
     @Override
-    public String provideCoordinates(final String group, final String artifact, final String version) {
+    public String provideCoordinates(final String group, final String artifact, final String version, String packaging) {
         return "implementation(\"%s:%s:%s\")".formatted(group, artifact, version);
     }
 }

--- a/src/main/java/it/mulders/mcs/search/printer/GrapeOutput.java
+++ b/src/main/java/it/mulders/mcs/search/printer/GrapeOutput.java
@@ -3,7 +3,7 @@ package it.mulders.mcs.search.printer;
 public final class GrapeOutput implements CoordinatePrinter {
 
     @Override
-    public String provideCoordinates(final String group, final String artifact, final String version) {
+    public String provideCoordinates(final String group, final String artifact, final String version, String packaging) {
         return """
                 @Grapes(
                     @Grab(group='%s', module='%s', version='%s')

--- a/src/main/java/it/mulders/mcs/search/printer/IvyXmlOutput.java
+++ b/src/main/java/it/mulders/mcs/search/printer/IvyXmlOutput.java
@@ -3,7 +3,7 @@ package it.mulders.mcs.search.printer;
 public final class IvyXmlOutput implements CoordinatePrinter {
 
     @Override
-    public String provideCoordinates(final String group, final String artifact, final String version) {
+    public String provideCoordinates(final String group, final String artifact, final String version, String packaging) {
         return """
                 <dependency org="%s" name="%s" rev="%s"/>
                 """.formatted(group, artifact, version);

--- a/src/main/java/it/mulders/mcs/search/printer/LeiningenOutput.java
+++ b/src/main/java/it/mulders/mcs/search/printer/LeiningenOutput.java
@@ -3,7 +3,7 @@ package it.mulders.mcs.search.printer;
 public final class LeiningenOutput implements CoordinatePrinter {
 
     @Override
-    public String provideCoordinates(final String group, final String artifact, final String version) {
+    public String provideCoordinates(final String group, final String artifact, final String version, String packaging) {
         return "[%s/%s \"%s\"]".formatted(group, artifact, version);
     }
 }

--- a/src/main/java/it/mulders/mcs/search/printer/PomXmlOutput.java
+++ b/src/main/java/it/mulders/mcs/search/printer/PomXmlOutput.java
@@ -3,13 +3,14 @@ package it.mulders.mcs.search.printer;
 public final class PomXmlOutput implements CoordinatePrinter {
 
     @Override
-    public String provideCoordinates(final String group, final String artifact, final String version) {
+    public String provideCoordinates(final String group, final String artifact, final String version, String packaging) {
+        String element = "maven-plugin".equals(packaging) ? "plugin" : "dependency";
         return """
-                    <dependency>
+                    <%4$s>
                         <groupId>%s</groupId>
                         <artifactId>%s</artifactId>
                         <version>%s</version>
-                    </dependency>
-                """.formatted(group, artifact, version);
+                    </%4$s>
+                """.formatted(group, artifact, version, element);
     }
 }

--- a/src/main/java/it/mulders/mcs/search/printer/SbtOutput.java
+++ b/src/main/java/it/mulders/mcs/search/printer/SbtOutput.java
@@ -3,7 +3,7 @@ package it.mulders.mcs.search.printer;
 public final class SbtOutput implements CoordinatePrinter {
 
     @Override
-    public String provideCoordinates(final String group, final String artifact, final String version) {
+    public String provideCoordinates(final String group, final String artifact, final String version, String packaging) {
         return """
                 libraryDependencies += "%s" %% "%s" %% "%s"
                 """.formatted(group, artifact, version);

--- a/src/test/java/it/mulders/mcs/search/printer/CoordinatePrinterTest.java
+++ b/src/test/java/it/mulders/mcs/search/printer/CoordinatePrinterTest.java
@@ -14,6 +14,17 @@ import java.util.stream.Stream;
 class CoordinatePrinterTest implements WithAssertions {
 
     private static final SearchQuery QUERY = SearchQuery.search("org.codehaus.plexus:plexus-utils").build();
+    private static final SearchResponse.Response PLUGIN_RESPONSE = new SearchResponse.Response(1, 0, new SearchResponse.Response.Doc[]{
+        new SearchResponse.Response.Doc(
+            "org.apache.maven.plugins:maven-jar-plugin:3.3.0",
+            "org.apache.maven.plugins",
+            "maven-jar-plugin",
+            "3.3.0",
+            null,
+            "maven-plugin",
+            1630022910000L
+        )
+    });
     private static final SearchResponse.Response RESPONSE =
             new SearchResponse.Response(1, 0, new SearchResponse.Response.Doc[]{
                     new SearchResponse.Response.Doc(
@@ -26,12 +37,19 @@ class CoordinatePrinterTest implements WithAssertions {
                             1630022910000L
                     )
             });
-    private static final String POM_XML_OUTPUT = """
+    private static final String POM_XML_DEPENDENCY_OUTPUT = """
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-utils</artifactId>
                 <version>3.4.1</version>
             </dependency>
+            """;
+    private static final String POM_XML_PLUGIN_OUTPUT = """
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+            </plugin>
             """;
     private static final String GRADLE_GROOVY_OUTPUT = "implementation group: 'org.codehaus.plexus', name: 'plexus-utils', version: '3.4.1'";
     private static final String GRADLE_GROOVY_SHORT_OUTPUT = "implementation 'org.codehaus.plexus:plexus-utils:3.4.1'";
@@ -54,22 +72,23 @@ class CoordinatePrinterTest implements WithAssertions {
 
     private static Stream<Arguments> coordinatePrinters() {
         return Stream.of(
-                Arguments.of(new PomXmlOutput(), POM_XML_OUTPUT),
-                Arguments.of(new GradleGroovyOutput(), GRADLE_GROOVY_OUTPUT),
-                Arguments.of(new GradleGroovyShortOutput(), GRADLE_GROOVY_SHORT_OUTPUT),
-                Arguments.of(new GradleKotlinOutput(), GRADLE_KOTLIN_OUTPUT),
-                Arguments.of(new SbtOutput(), SBT_OUTPUT),
-                Arguments.of(new IvyXmlOutput(), IVY_XML_OUTPUT),
-                Arguments.of(new GrapeOutput(), GRAPE_OUTPUT),
-                Arguments.of(new LeiningenOutput(), LEININGEN_OUTPUT),
-                Arguments.of(new BuildrOutput(), BUILDR_OUTPUT)
+                Arguments.of(new PomXmlOutput(), POM_XML_DEPENDENCY_OUTPUT, RESPONSE),
+                Arguments.of(new PomXmlOutput(), POM_XML_PLUGIN_OUTPUT, PLUGIN_RESPONSE),
+                Arguments.of(new GradleGroovyOutput(), GRADLE_GROOVY_OUTPUT, RESPONSE),
+                Arguments.of(new GradleGroovyShortOutput(), GRADLE_GROOVY_SHORT_OUTPUT, RESPONSE),
+                Arguments.of(new GradleKotlinOutput(), GRADLE_KOTLIN_OUTPUT, RESPONSE),
+                Arguments.of(new SbtOutput(), SBT_OUTPUT, RESPONSE),
+                Arguments.of(new IvyXmlOutput(), IVY_XML_OUTPUT, RESPONSE),
+                Arguments.of(new GrapeOutput(), GRAPE_OUTPUT, RESPONSE),
+                Arguments.of(new LeiningenOutput(), LEININGEN_OUTPUT, RESPONSE),
+                Arguments.of(new BuildrOutput(), BUILDR_OUTPUT, RESPONSE)
         );
     }
 
     @ParameterizedTest
     @MethodSource("coordinatePrinters")
-    void should_print_snippet(CoordinatePrinter printer, String expected) {
-        printer.print(QUERY, RESPONSE, new PrintStream(buffer));
+    void should_print_snippet(CoordinatePrinter printer, String expected, SearchResponse.Response response) {
+        printer.print(QUERY, response, new PrintStream(buffer));
         var xml = buffer.toString();
 
         assertThat(xml).isEqualToIgnoringWhitespace(expected);


### PR DESCRIPTION
Closes #232

---

I initially wanted to avoid changing the interface as the rest of the `Output` classes do not use the packaging but that required more refactoring and touching the creation logic. E.g. you would have to determine the type of `POMOutput` based on the response instead of just the current `--format` flag.

I'm less familiar with the other tools, but a quick google showed me that Gradle does also have a different syntax for plugins however it uses a 'core' plugin group and a different plugin hub. Perhaps something to look into in the future. 

So I opted for placing it in the `PomXMLOutput` which IMO does make sense anyway as it is responsible for displaying the output as this is POM specific formatting.

