### PR TITLE
Display vulnerabilities for returned dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <junit-jupiter.version>5.10.0</junit-jupiter.version>
         <picocli.version>4.7.4</picocli.version>
         <wiremock.version>2.35.0</wiremock.version>
+        <packageurl.version>1.4.1</packageurl.version>
 
         <artifactsDir>target/distributions</artifactsDir>
         <executable-suffix></executable-suffix>
@@ -261,6 +262,11 @@
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
             <version>${picocli.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.package-url</groupId>
+            <artifactId>packageurl-java</artifactId>
+            <version>${packageurl.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <picocli.version>4.7.4</picocli.version>
         <wiremock.version>2.35.0</wiremock.version>
         <packageurl.version>1.4.1</packageurl.version>
+        <junit-pioneer.version>2.1.0</junit-pioneer.version>
 
         <artifactsDir>target/distributions</artifactsDir>
         <executable-suffix></executable-suffix>
@@ -308,7 +309,12 @@
             <version>1.2.1</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <version>${junit-pioneer.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/src/main/java/it/mulders/mcs/cli/Cli.java
+++ b/src/main/java/it/mulders/mcs/cli/Cli.java
@@ -73,6 +73,13 @@ public class Cli {
         )
         private String responseFormat;
 
+        @CommandLine.Option(
+                names = { "-s", "--show-vulnerabilities" },
+                description = "Show any vulnerabilities for returned components",
+                paramLabel = "<vulnerabilities>"
+        )
+        private boolean showVulnerabilities;
+
         @Override
         public Integer call() {
             var combinedQuery = String.join(" ", query);

--- a/src/main/java/it/mulders/mcs/cli/Cli.java
+++ b/src/main/java/it/mulders/mcs/cli/Cli.java
@@ -75,7 +75,7 @@ public class Cli {
 
         @CommandLine.Option(
                 names = { "-s", "--show-vulnerabilities" },
-                description = "Show any vulnerabilities for returned components",
+                description = "Show reported security vulnerabilities",
                 paramLabel = "<vulnerabilities>"
         )
         private boolean showVulnerabilities;

--- a/src/main/java/it/mulders/mcs/cli/Cli.java
+++ b/src/main/java/it/mulders/mcs/cli/Cli.java
@@ -89,7 +89,7 @@ public class Cli {
                     .build();
 
             CoordinatePrinter coordinatePrinter = FormatType.providePrinter(responseFormat);
-            var searchCommandHandler = new SearchCommandHandler(coordinatePrinter);
+            var searchCommandHandler = new SearchCommandHandler(coordinatePrinter, showVulnerabilities);
             searchCommandHandler.search(searchQuery);
             return 0;
         }

--- a/src/main/java/it/mulders/mcs/search/SearchCommandHandler.java
+++ b/src/main/java/it/mulders/mcs/search/SearchCommandHandler.java
@@ -81,7 +81,7 @@ public class SearchCommandHandler {
             reportClient.search(searchResponse.docs())
                 .ifPresentOrElse(
                     componentResponse -> processComponentReports(componentResponse.componentReports(), searchResponse.docs()),
-                    failure -> { throw new RuntimeException(failure); });
+                    failure -> { throw new McsRuntimeException(failure); });
         }
         printResponse(query, searchResponse);
     }

--- a/src/main/java/it/mulders/mcs/search/SearchCommandHandler.java
+++ b/src/main/java/it/mulders/mcs/search/SearchCommandHandler.java
@@ -7,6 +7,7 @@ import it.mulders.mcs.common.Result;
 import it.mulders.mcs.search.printer.DelegatingOutputPrinter;
 import it.mulders.mcs.search.printer.OutputPrinter;
 import it.mulders.mcs.search.vulnerability.ComponentReportClient;
+import it.mulders.mcs.search.vulnerability.ComponentReportResponse.ComponentReport;
 
 import static it.mulders.mcs.search.Constants.MAX_LIMIT;
 
@@ -79,11 +80,17 @@ public class SearchCommandHandler {
         if (showVulnerabilities) {
             reportClient.search(searchResponse.docs())
                 .ifPresentOrElse(
-                    componentResponse -> Stream.of(componentResponse.componentReports()).forEach(componentReport ->
-                        reportClient.assignComponentReport(componentReport, searchResponse.docs())),
+                    componentResponse -> processComponentReports(componentResponse.componentReports(), searchResponse.docs()),
                     failure -> { throw new RuntimeException(failure); });
         }
         printResponse(query, searchResponse);
+    }
+
+    private void processComponentReports(final ComponentReport[] componentReports,
+                                         final SearchResponse.Response.Doc[] docs) {
+        Stream.of(componentReports)
+            .forEach(componentReport ->
+                reportClient.assignComponentReport(componentReport, docs));
     }
 
     private void printResponse(final SearchQuery query, final SearchResponse.Response response) {

--- a/src/main/java/it/mulders/mcs/search/SearchCommandHandler.java
+++ b/src/main/java/it/mulders/mcs/search/SearchCommandHandler.java
@@ -22,7 +22,7 @@ public class SearchCommandHandler {
     }
 
     public SearchCommandHandler(final OutputPrinter coordinateOutput, final boolean showVulnerabilities) {
-        this(new DelegatingOutputPrinter(coordinateOutput), showVulnerabilities, new SearchClient(), new ComponentReportClient());
+        this(new DelegatingOutputPrinter(coordinateOutput, showVulnerabilities), showVulnerabilities, new SearchClient(), new ComponentReportClient());
     }
 
     // Visible for testing

--- a/src/main/java/it/mulders/mcs/search/SearchResponse.java
+++ b/src/main/java/it/mulders/mcs/search/SearchResponse.java
@@ -1,8 +1,17 @@
 package it.mulders.mcs.search;
 
+import it.mulders.mcs.search.vulnerability.ComponentReportResponse.ComponentReport;
+
 public record SearchResponse(Object responseHeader, Response response) {
     public record Response(int numFound, int start, Doc[] docs) {
-        public record Doc(String id, String g, String a, String v, String latestVersion, String p, long timestamp) {
+        public record Doc(String id, String g, String a, String v, String latestVersion, String p, long timestamp, ComponentReport componentReport) {
+            public Doc(String id, String g, String a, String v, String latestVersion, String p, long timestamp) {
+                this(id, g, a, v, latestVersion, p, timestamp, null);
+            }
+
+            public Doc withComponentReport(ComponentReport componentReport) {
+                return new Doc(id(), g(), a(), v(), latestVersion(), p(), timestamp(), componentReport);
+            }
         }
     }
 }

--- a/src/main/java/it/mulders/mcs/search/printer/CoordinatePrinter.java
+++ b/src/main/java/it/mulders/mcs/search/printer/CoordinatePrinter.java
@@ -2,8 +2,12 @@ package it.mulders.mcs.search.printer;
 
 import it.mulders.mcs.search.SearchQuery;
 import it.mulders.mcs.search.SearchResponse;
+import it.mulders.mcs.search.vulnerability.ComponentReportResponse;
+import it.mulders.mcs.search.vulnerability.ComponentReportResponse.ComponentReport.ComponentReportVulnerability;
 
 import java.io.PrintStream;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public sealed interface CoordinatePrinter extends OutputPrinter
         permits BuildrOutput, GradleGroovyOutput, GradleGroovyShortOutput, GradleKotlinOutput, GrapeOutput,
@@ -21,6 +25,7 @@ public sealed interface CoordinatePrinter extends OutputPrinter
         stream.println();
         stream.println(provideCoordinates(doc.g(), doc.a(), first(doc.v(), doc.latestVersion()), doc.p()));
         stream.println();
+        printVulnerabilities(doc.componentReport(), stream);
     }
 
     private String first(final String... values) {
@@ -30,5 +35,20 @@ public sealed interface CoordinatePrinter extends OutputPrinter
             }
         }
         return null;
+    }
+
+    private void printVulnerabilities(final ComponentReportResponse.ComponentReport componentReport,
+                                      final PrintStream stream) {
+        if (componentReport != null && componentReport.vulnerabilities().length > 0) {
+            var text = "Found %s vulnerabilities %s"
+                .formatted(
+                    componentReport.vulnerabilities().length,
+                    Stream.of(componentReport.vulnerabilities())
+                        .map(ComponentReportVulnerability::id)
+                        .collect(Collectors.joining(", ", "(", ")"))
+                );
+            stream.println(text);
+            stream.println("Reference: " + componentReport.reference());
+        }
     }
 }

--- a/src/main/java/it/mulders/mcs/search/printer/CoordinatePrinter.java
+++ b/src/main/java/it/mulders/mcs/search/printer/CoordinatePrinter.java
@@ -41,7 +41,7 @@ public sealed interface CoordinatePrinter extends OutputPrinter
                                       final PrintStream stream) {
         if (componentReport != null) { // will be null if --show-vulnerabilities cli arg is false
             if (componentReport.vulnerabilities().length == 0) {
-                stream.println("No vulnerabilities found");
+                stream.println("No vulnerabilities reported");
             } else {
                 stream.println("Vulnerabilities:");
                 Arrays.stream(componentReport.vulnerabilitiesSortedByCvssScore())

--- a/src/main/java/it/mulders/mcs/search/printer/CoordinatePrinter.java
+++ b/src/main/java/it/mulders/mcs/search/printer/CoordinatePrinter.java
@@ -1,12 +1,13 @@
 package it.mulders.mcs.search.printer;
 
-import java.io.PrintStream;
 import java.util.Arrays;
 
 import it.mulders.mcs.search.SearchQuery;
 import it.mulders.mcs.search.SearchResponse;
 import it.mulders.mcs.search.vulnerability.ComponentReportResponse;
 import it.mulders.mcs.search.vulnerability.ComponentReportVulnerabilitySeverity;
+
+import java.io.PrintStream;
 
 public sealed interface CoordinatePrinter extends OutputPrinter
         permits BuildrOutput, GradleGroovyOutput, GradleGroovyShortOutput, GradleKotlinOutput, GrapeOutput,

--- a/src/main/java/it/mulders/mcs/search/printer/CoordinatePrinter.java
+++ b/src/main/java/it/mulders/mcs/search/printer/CoordinatePrinter.java
@@ -39,12 +39,16 @@ public sealed interface CoordinatePrinter extends OutputPrinter
 
     private void printVulnerabilities(final ComponentReportResponse.ComponentReport componentReport,
                                       final PrintStream stream) {
-        if (componentReport != null) {
-            stream.println("Vulnerabilities:");
-            Arrays.stream(componentReport.vulnerabilitiesSortedByCvssScore())
-                .forEachOrdered(vul ->
-                    stream.println(vul.id() + " ("+ ComponentReportVulnerabilitySeverity.getText(vul.cvssScore()) +")" + " - " + vul.reference())
-                );
+        if (componentReport != null) { // will be null if --show-vulnerabilities cli arg is false
+            if (componentReport.vulnerabilities().length == 0) {
+                stream.println("No vulnerabilities found");
+            } else {
+                stream.println("Vulnerabilities:");
+                Arrays.stream(componentReport.vulnerabilitiesSortedByCvssScore())
+                    .forEachOrdered(vul ->
+                        stream.println(vul.id() + " ("+ ComponentReportVulnerabilitySeverity.getText(vul.cvssScore()) +")" + " - " + vul.reference())
+                    );
+            }
         }
     }
 }

--- a/src/main/java/it/mulders/mcs/search/printer/CoordinatePrinter.java
+++ b/src/main/java/it/mulders/mcs/search/printer/CoordinatePrinter.java
@@ -1,10 +1,12 @@
 package it.mulders.mcs.search.printer;
 
 import java.io.PrintStream;
+import java.util.Arrays;
 
 import it.mulders.mcs.search.SearchQuery;
 import it.mulders.mcs.search.SearchResponse;
 import it.mulders.mcs.search.vulnerability.ComponentReportResponse;
+import it.mulders.mcs.search.vulnerability.ComponentReportVulnerabilitySeverity;
 
 public sealed interface CoordinatePrinter extends OutputPrinter
         permits BuildrOutput, GradleGroovyOutput, GradleGroovyShortOutput, GradleKotlinOutput, GrapeOutput,
@@ -37,12 +39,11 @@ public sealed interface CoordinatePrinter extends OutputPrinter
     private void printVulnerabilities(final ComponentReportResponse.ComponentReport componentReport,
                                       final PrintStream stream) {
         if (componentReport != null) {
-            String vulnerabilityText =  switch(componentReport.vulnerabilities().length) {
-                case 0 -> "";
-                case 1 -> "Found 1 vulnerability";
-                default -> "Found %s vulnerabilities".formatted(componentReport.vulnerabilities().length);
-            };
-            stream.println(vulnerabilityText);
+            stream.println("Vulnerabilities:");
+            Arrays.stream(componentReport.vulnerabilitiesSortedByCvssScore())
+                .forEachOrdered(vul ->
+                    stream.println(vul.id() + " ("+ ComponentReportVulnerabilitySeverity.getText(vul.cvssScore()) +")" + " - " + vul.reference())
+                );
         }
     }
 }

--- a/src/main/java/it/mulders/mcs/search/printer/CoordinatePrinter.java
+++ b/src/main/java/it/mulders/mcs/search/printer/CoordinatePrinter.java
@@ -1,13 +1,10 @@
 package it.mulders.mcs.search.printer;
 
+import java.io.PrintStream;
+
 import it.mulders.mcs.search.SearchQuery;
 import it.mulders.mcs.search.SearchResponse;
 import it.mulders.mcs.search.vulnerability.ComponentReportResponse;
-import it.mulders.mcs.search.vulnerability.ComponentReportResponse.ComponentReport.ComponentReportVulnerability;
-
-import java.io.PrintStream;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public sealed interface CoordinatePrinter extends OutputPrinter
         permits BuildrOutput, GradleGroovyOutput, GradleGroovyShortOutput, GradleKotlinOutput, GrapeOutput,
@@ -39,16 +36,13 @@ public sealed interface CoordinatePrinter extends OutputPrinter
 
     private void printVulnerabilities(final ComponentReportResponse.ComponentReport componentReport,
                                       final PrintStream stream) {
-        if (componentReport != null && componentReport.vulnerabilities().length > 0) {
-            var text = "Found %s vulnerabilities %s"
-                .formatted(
-                    componentReport.vulnerabilities().length,
-                    Stream.of(componentReport.vulnerabilities())
-                        .map(ComponentReportVulnerability::id)
-                        .collect(Collectors.joining(", ", "(", ")"))
-                );
-            stream.println(text);
-            stream.println("Reference: " + componentReport.reference());
+        if (componentReport != null) {
+            String vulnerabilityText =  switch(componentReport.vulnerabilities().length) {
+                case 0 -> "";
+                case 1 -> "Found 1 vulnerability";
+                default -> "Found %s vulnerabilities".formatted(componentReport.vulnerabilities().length);
+            };
+            stream.println(vulnerabilityText);
         }
     }
 }

--- a/src/main/java/it/mulders/mcs/search/printer/DelegatingOutputPrinter.java
+++ b/src/main/java/it/mulders/mcs/search/printer/DelegatingOutputPrinter.java
@@ -1,9 +1,9 @@
 package it.mulders.mcs.search.printer;
 
-import java.io.PrintStream;
-
 import it.mulders.mcs.search.SearchQuery;
 import it.mulders.mcs.search.SearchResponse;
+
+import java.io.PrintStream;
 
 /**
  * Output printer that delegates to a different printer, depending on the number of search results.

--- a/src/main/java/it/mulders/mcs/search/printer/DelegatingOutputPrinter.java
+++ b/src/main/java/it/mulders/mcs/search/printer/DelegatingOutputPrinter.java
@@ -1,9 +1,9 @@
 package it.mulders.mcs.search.printer;
 
+import java.io.PrintStream;
+
 import it.mulders.mcs.search.SearchQuery;
 import it.mulders.mcs.search.SearchResponse;
-
-import java.io.PrintStream;
 
 /**
  * Output printer that delegates to a different printer, depending on the number of search results.
@@ -14,7 +14,11 @@ public class DelegatingOutputPrinter implements OutputPrinter {
     private final OutputPrinter tabularSearchOutput;
 
     public DelegatingOutputPrinter(final OutputPrinter coordinateOutput) {
-        this(new NoOutputPrinter(), coordinateOutput, new TabularOutputPrinter());
+        this(coordinateOutput, false);
+    }
+
+    public DelegatingOutputPrinter(final OutputPrinter coordinateOutput, final boolean showVulnerabilities) {
+        this(new NoOutputPrinter(), coordinateOutput, new TabularOutputPrinter(showVulnerabilities));
     }
 
     // Visible for testing

--- a/src/main/java/it/mulders/mcs/search/printer/TabularOutputPrinter.java
+++ b/src/main/java/it/mulders/mcs/search/printer/TabularOutputPrinter.java
@@ -81,20 +81,22 @@ public class TabularOutputPrinter implements OutputPrinter {
     }
 
     private void printRow(final Help.TextTable table, final SearchResponse.Response.Doc doc) {
-      var vulnerabilityText = "";
-      if (showVulnerabilities && doc.componentReport() != null) {
-        vulnerabilityText = getVulnerabilityText(doc.componentReport());
-      }
+        var lastUpdated = DATE_TIME_FORMATTER.format(
+                Instant.ofEpochMilli(doc.timestamp()).atZone(ZoneId.systemDefault())
+        );
 
-      var lastUpdated = DATE_TIME_FORMATTER.format(Instant.ofEpochMilli(doc.timestamp()).atZone(ZoneId.systemDefault()));
+        var entry = displayEntry(doc);
 
-      var entry = displayEntry(doc);
+        var vulnerabilityText = "";
+        if (showVulnerabilities && doc.componentReport() != null) {
+            vulnerabilityText = getVulnerabilityText(doc.componentReport());
+        }
 
-      if (showVulnerabilities) {
-        table.addRowValues(entry, lastUpdated, vulnerabilityText);
-      } else {
-        table.addRowValues(entry, lastUpdated);
-      }
+        if (showVulnerabilities) {
+            table.addRowValues(entry, lastUpdated, vulnerabilityText);
+        } else {
+            table.addRowValues(entry, lastUpdated);
+        }
     }
 
     private String getVulnerabilityText(ComponentReport componentReport) {

--- a/src/main/java/it/mulders/mcs/search/printer/TabularOutputPrinter.java
+++ b/src/main/java/it/mulders/mcs/search/printer/TabularOutputPrinter.java
@@ -1,15 +1,5 @@
 package it.mulders.mcs.search.printer;
 
-import java.io.PrintStream;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 import it.mulders.mcs.search.SearchQuery;
 import it.mulders.mcs.search.SearchResponse;
 import it.mulders.mcs.search.vulnerability.ComponentReportResponse.ComponentReport;
@@ -19,6 +9,16 @@ import picocli.CommandLine;
 import picocli.CommandLine.Help;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Help.Column.Overflow;
+
+import java.io.PrintStream;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class TabularOutputPrinter implements OutputPrinter {
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(

--- a/src/main/java/it/mulders/mcs/search/printer/TabularOutputPrinter.java
+++ b/src/main/java/it/mulders/mcs/search/printer/TabularOutputPrinter.java
@@ -8,12 +8,14 @@ import it.mulders.mcs.search.vulnerability.ComponentReportVulnerabilitySeverity;
 import picocli.CommandLine;
 import picocli.CommandLine.Help;
 import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Help.Column;
 import picocli.CommandLine.Help.Column.Overflow;
 
 import java.io.PrintStream;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -51,13 +53,7 @@ public class TabularOutputPrinter implements OutputPrinter {
 
         var colorScheme = Help.defaultColorScheme(Ansi.AUTO);
 
-        var maxKeyLength = calculateCoordinateColumnWidth(response.docs());
-
-        var table = CommandLine.Help.TextTable.forColumns(colorScheme,
-                new CommandLine.Help.Column(maxKeyLength + SPACING, INDENT, Overflow.SPAN),
-                new CommandLine.Help.Column(30, INDENT, Overflow.WRAP),
-                new CommandLine.Help.Column(300, INDENT, Overflow.SPAN)
-        );
+        var table = CommandLine.Help.TextTable.forColumns(colorScheme, constructColumns(response));
 
         if (showVulnerabilities) {
           table.addRowValues("Coordinates", "Last updated", "Vulnerabilities");
@@ -70,6 +66,16 @@ public class TabularOutputPrinter implements OutputPrinter {
         Arrays.stream(response.docs()).forEach(doc -> printRow(table, doc));
 
         stream.println(table);
+    }
+
+    private Column[] constructColumns(final SearchResponse.Response response) {
+        var cols = new ArrayList<Column>();
+        cols.add(new CommandLine.Help.Column(calculateCoordinateColumnWidth(response.docs()) + SPACING, INDENT, Overflow.SPAN));
+        cols.add(new CommandLine.Help.Column(30, INDENT, Overflow.WRAP));
+        if (showVulnerabilities) {
+            cols.add(new CommandLine.Help.Column(50, INDENT, Overflow.SPAN));
+        }
+        return cols.toArray(Column[]::new);
     }
 
     private int calculateCoordinateColumnWidth(final SearchResponse.Response.Doc[] results) {

--- a/src/main/java/it/mulders/mcs/search/printer/TabularOutputPrinter.java
+++ b/src/main/java/it/mulders/mcs/search/printer/TabularOutputPrinter.java
@@ -1,17 +1,20 @@
 package it.mulders.mcs.search.printer;
 
-import it.mulders.mcs.search.SearchQuery;
-import it.mulders.mcs.search.SearchResponse;
-import picocli.CommandLine;
-import picocli.CommandLine.Help;
-import picocli.CommandLine.Help.Ansi;
-import picocli.CommandLine.Help.Column.Overflow;
-
 import java.io.PrintStream;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import it.mulders.mcs.search.SearchQuery;
+import it.mulders.mcs.search.SearchResponse;
+import it.mulders.mcs.search.vulnerability.ComponentReportResponse.ComponentReport.ComponentReportVulnerability;
+import picocli.CommandLine;
+import picocli.CommandLine.Help;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Help.Column.Overflow;
 
 public class TabularOutputPrinter implements OutputPrinter {
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(
@@ -38,11 +41,12 @@ public class TabularOutputPrinter implements OutputPrinter {
 
         var table = CommandLine.Help.TextTable.forColumns(colorScheme,
                 new CommandLine.Help.Column(maxKeyLength + SPACING, INDENT, Overflow.SPAN),
-                new CommandLine.Help.Column(30, INDENT, Overflow.WRAP)
+                new CommandLine.Help.Column(30, INDENT, Overflow.WRAP),
+                new CommandLine.Help.Column(300, INDENT, Overflow.SPAN)
         );
 
-        table.addRowValues("Coordinates", "Last updated");
-        table.addRowValues("===========", "============");
+        table.addRowValues("Coordinates", "Last updated", "Vulnerabilities");
+        table.addRowValues("===========", "============", "===============");
         Arrays.stream(response.docs()).forEach(doc -> printRow(table, doc));
 
         stream.println(table);
@@ -57,13 +61,29 @@ public class TabularOutputPrinter implements OutputPrinter {
     }
 
     private void printRow(final Help.TextTable table, final SearchResponse.Response.Doc doc) {
+       var vulnerabilities = "";
+       if (doc.componentReport() != null) {
+            var numVuls = doc.componentReport().vulnerabilities().length;
+            if (numVuls > 0) {
+              vulnerabilities += "Found " + numVuls + " vulnerabilities ";
+              //vulnerabilities += doc.componentReport().reference();
+              vulnerabilities += Stream.of(doc.componentReport().vulnerabilities())
+                  .map(ComponentReportVulnerability::id).collect(Collectors.joining(", ", "(", ")"));
+            }
+
+       }
+
         var lastUpdated = DATE_TIME_FORMATTER.format(
                 Instant.ofEpochMilli(doc.timestamp()).atZone(ZoneId.systemDefault())
         );
 
         var entry = displayEntry(doc);
 
-        table.addRowValues(entry, lastUpdated);
+        if (vulnerabilities != "") {
+            table.addRowValues(entry, lastUpdated, vulnerabilities);
+        } else {
+            table.addRowValues(entry, lastUpdated);
+        }
     }
 
     private String displayEntry(final SearchResponse.Response.Doc doc) {

--- a/src/main/java/it/mulders/mcs/search/printer/TabularOutputPrinter.java
+++ b/src/main/java/it/mulders/mcs/search/printer/TabularOutputPrinter.java
@@ -96,15 +96,16 @@ public class TabularOutputPrinter implements OutputPrinter {
         if (!showVulnerabilities) {
             table.addRowValues(entry, lastUpdated);
         } else {
-            var vulnerabilityText = "";
-            if (doc.componentReport() != null) {
-                vulnerabilityText = getVulnerabilityText(doc.componentReport());
-            }
+            var vulnerabilityText = getVulnerabilityText(doc.componentReport());
             table.addRowValues(entry, lastUpdated, vulnerabilityText);
         }
     }
 
     private String getVulnerabilityText(ComponentReport componentReport) {
+      if (componentReport == null || componentReport.vulnerabilities().length == 0) {
+        return "-";
+      }
+
       ComponentReportVulnerability[] sorted = componentReport.vulnerabilitiesSortedByCvssScore();
 
       Map<String, Long> counts = Arrays.stream(sorted)

--- a/src/main/java/it/mulders/mcs/search/printer/TabularOutputPrinter.java
+++ b/src/main/java/it/mulders/mcs/search/printer/TabularOutputPrinter.java
@@ -87,15 +87,14 @@ public class TabularOutputPrinter implements OutputPrinter {
 
         var entry = displayEntry(doc);
 
-        var vulnerabilityText = "";
-        if (showVulnerabilities && doc.componentReport() != null) {
-            vulnerabilityText = getVulnerabilityText(doc.componentReport());
-        }
-
-        if (showVulnerabilities) {
-            table.addRowValues(entry, lastUpdated, vulnerabilityText);
-        } else {
+        if (!showVulnerabilities) {
             table.addRowValues(entry, lastUpdated);
+        } else {
+            var vulnerabilityText = "";
+            if (doc.componentReport() != null) {
+                vulnerabilityText = getVulnerabilityText(doc.componentReport());
+            }
+            table.addRowValues(entry, lastUpdated, vulnerabilityText);
         }
     }
 

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
@@ -17,6 +17,11 @@ import it.mulders.mcs.common.Result;
 import it.mulders.mcs.search.SearchResponse;
 
 public class ComponentReportClient {
+  private static final String MISSING_OSS_INDEX_CREDENTIALS_WARNING = """
+      You've requested to show reported security vulnerabilities, but you haven't configured a username and password
+      for the Sonatype OSS Index. See https://ossindex.sonatype.org for details on how this may impact your usage.
+      """.strip();
+
   private final String hostname;
   private final HttpClient client = HttpClient.newHttpClient();
 
@@ -51,6 +56,7 @@ public class ComponentReportClient {
       builder.header("Authorization", getBasicAuthenticationHeader(username, password));
     } else {
       builder.uri(URI.create(String.format("%s/api/v3/component-report", hostname)));
+      System.out.println(MISSING_OSS_INDEX_CREDENTIALS_WARNING);
     }
 
     try {

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
@@ -68,8 +68,7 @@ public class ComponentReportClient {
   public String toPackageUrls(final SearchResponse.Response.Doc doc) {
     try {
       return new PackageURL("maven", doc.g(), doc.a(), doc.v(), null, null).canonicalize();
-    }
-    catch (MalformedPackageURLException e) {
+    } catch (MalformedPackageURLException e) {
       throw new McsRuntimeException(e);
     }
   }
@@ -85,8 +84,7 @@ public class ComponentReportClient {
           docs[i] = doc;
           break;
         }
-      }
-      catch (MalformedPackageURLException e) {
+      } catch (MalformedPackageURLException e) {
         throw new McsRuntimeException(e);
       }
     }

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
@@ -50,11 +50,11 @@ public class ComponentReportClient {
     var username = System.getProperty("ossindex.username", "");
     var password = System.getProperty("ossindex.password", "");
 
-    if (username.isEmpty() || password.isEmpty()) {
-      builder.uri(URI.create(String.format("%s/api/v3/component-report", hostname)));
-    } else {
+    if (!username.isEmpty() || !password.isEmpty()) {
       builder.uri(URI.create(String.format("%s/api/v3/authorized/component-report", hostname)));
       builder.header("Authorization", getBasicAuthenticationHeader(username, password));
+    } else {
+      builder.uri(URI.create(String.format("%s/api/v3/component-report", hostname)));
     }
 
     try {

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
@@ -39,12 +39,11 @@ public class ComponentReportClient {
 
   public Result<ComponentReportResponse> search(final List<String> coordinates) {
     var purls = coordinates.stream().map(purl -> "\"" + purl + "\"").collect(Collectors.joining(","));
-
-    var json = "{\"coordinates\" : [%s]}";
+    var json = "{\"coordinates\" : [%s]}".formatted(purls);
 
     var builder = HttpRequest.newBuilder()
     .version(HttpClient.Version.HTTP_1_1)
-    .POST(HttpRequest.BodyPublishers.ofString(json.formatted(purls)))
+    .POST(HttpRequest.BodyPublishers.ofString(json))
     .header("Content-Type", "application/json");
 
     var username = System.getProperty("ossindex.username", "");

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
@@ -74,6 +74,7 @@ public class ComponentReportClient {
         if (matches(packageURL, doc)) {
           doc = doc.withComponentReport(componentReport);
           docs[i] = doc;
+          break;
         }
       }
       catch (MalformedPackageURLException e) {

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
@@ -19,8 +19,7 @@ import it.mulders.mcs.search.SearchResponse;
 public class ComponentReportClient {
   private static final String MISSING_OSS_INDEX_CREDENTIALS_WARNING = """
       You've requested to show reported security vulnerabilities, but you haven't configured a username and password
-      for the Sonatype OSS Index. See https://ossindex.sonatype.org for details on how this may impact your usage.
-      """.strip();
+      for the Sonatype OSS Index. See https://ossindex.sonatype.org for details on how this may impact your usage.""";
 
   private final String hostname;
   private final HttpClient client = HttpClient.newHttpClient();

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
@@ -1,0 +1,49 @@
+package it.mulders.mcs.search.vulnerability;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import it.mulders.mcs.common.Result;
+
+public class ComponentReportClient {
+  private final String hostname;
+  private final HttpClient client = HttpClient.newHttpClient();
+
+  public ComponentReportClient() {
+    this("https://ossindex.sonatype.org");
+  }
+
+  // Visible for testing
+  ComponentReportClient(final String hostname) {
+    this.hostname = hostname;
+  }
+
+  public Result<ComponentReportResponse> search(final List<String> coordinates) {
+    var uri = String.format("%s/api/v3/component-report", hostname);
+
+    var json = """
+            {
+              "coordinates" : [%s]
+            }
+            """;
+
+    var purls = coordinates.stream().map(purl -> "\"" + purl + "\"").collect(Collectors.joining(","));
+
+    var request = HttpRequest.newBuilder()
+        .version(HttpClient.Version.HTTP_1_1)
+        .uri(URI.create(uri))
+        .POST(HttpRequest.BodyPublishers.ofString(json.formatted(purls)))
+        .header("Content-Type", "application/json")
+        .build();
+
+    try {
+      return client.send(request, new ComponentReportResponseBodyHandler()).body();
+    } catch (IOException | InterruptedException e) {
+      return new Result.Failure<>(e);
+    }
+  }
+}

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
@@ -5,9 +5,14 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
 import it.mulders.mcs.common.Result;
+import it.mulders.mcs.search.SearchResponse;
 
 public class ComponentReportClient {
   private final String hostname;
@@ -20,6 +25,10 @@ public class ComponentReportClient {
   // Visible for testing
   ComponentReportClient(final String hostname) {
     this.hostname = hostname;
+  }
+
+  public Result<ComponentReportResponse> search(final SearchResponse.Response.Doc[] docs) {
+    return search(Stream.of(docs).map(this::toPackageUrls).toList());
   }
 
   public Result<ComponentReportResponse> search(final List<String> coordinates) {
@@ -45,5 +54,37 @@ public class ComponentReportClient {
     } catch (IOException | InterruptedException e) {
       return new Result.Failure<>(e);
     }
+  }
+
+  public String toPackageUrls(final SearchResponse.Response.Doc doc) {
+    try {
+      return new PackageURL("maven", doc.g(), doc.a(), doc.v(), null, null).canonicalize();
+    }
+    catch (MalformedPackageURLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void assignComponentReport(final ComponentReportResponse.ComponentReport componentReport,
+                                    final SearchResponse.Response.Doc[] docs) {
+    for (int i = 0; i < docs.length; i++) {
+      try {
+        PackageURL packageURL = new PackageURL(componentReport.coordinates());
+        SearchResponse.Response.Doc doc = docs[i];
+        if (matches(packageURL, doc)) {
+          doc = doc.withComponentReport(componentReport);
+          docs[i] = doc;
+        }
+      }
+      catch (MalformedPackageURLException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  private boolean matches(final PackageURL packageURL, final SearchResponse.Response.Doc doc) {
+    return Objects.equals(packageURL.getNamespace(), doc.g()) &&
+        Objects.equals(packageURL.getName(), doc.a()) &&
+        Objects.equals(packageURL.getVersion(), doc.v());
   }
 }

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
@@ -11,6 +11,7 @@ import java.util.stream.Stream;
 
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
+import it.mulders.mcs.common.McsRuntimeException;
 import it.mulders.mcs.common.Result;
 import it.mulders.mcs.search.SearchResponse;
 
@@ -61,7 +62,7 @@ public class ComponentReportClient {
       return new PackageURL("maven", doc.g(), doc.a(), doc.v(), null, null).canonicalize();
     }
     catch (MalformedPackageURLException e) {
-      throw new RuntimeException(e);
+      throw new McsRuntimeException(e);
     }
   }
 
@@ -78,7 +79,7 @@ public class ComponentReportClient {
         }
       }
       catch (MalformedPackageURLException e) {
-        throw new RuntimeException(e);
+        throw new McsRuntimeException(e);
       }
     }
   }

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.util.Base64;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -33,7 +34,7 @@ public class ComponentReportClient {
   }
 
   public Result<ComponentReportResponse> search(final List<String> coordinates) {
-    var uri = String.format("%s/api/v3/component-report", hostname);
+    var purls = coordinates.stream().map(purl -> "\"" + purl + "\"").collect(Collectors.joining(","));
 
     var json = """
             {
@@ -41,20 +42,31 @@ public class ComponentReportClient {
             }
             """;
 
-    var purls = coordinates.stream().map(purl -> "\"" + purl + "\"").collect(Collectors.joining(","));
+    var builder = HttpRequest.newBuilder()
+    .version(HttpClient.Version.HTTP_1_1)
+    .POST(HttpRequest.BodyPublishers.ofString(json.formatted(purls)))
+    .header("Content-Type", "application/json");
 
-    var request = HttpRequest.newBuilder()
-        .version(HttpClient.Version.HTTP_1_1)
-        .uri(URI.create(uri))
-        .POST(HttpRequest.BodyPublishers.ofString(json.formatted(purls)))
-        .header("Content-Type", "application/json")
-        .build();
+    var username = System.getProperty("ossindex.username", "");
+    var password = System.getProperty("ossindex.password", "");
+
+    if (username.isEmpty() || password.isEmpty()) {
+      builder.uri(URI.create(String.format("%s/api/v3/component-report", hostname)));
+    } else {
+      builder.uri(URI.create(String.format("%s/api/v3/authorized/component-report", hostname)));
+      builder.header("Authorization", getBasicAuthenticationHeader(username, password));
+    }
 
     try {
-      return client.send(request, new ComponentReportResponseBodyHandler()).body();
+      return client.send(builder.build(), new ComponentReportResponseBodyHandler()).body();
     } catch (IOException | InterruptedException e) {
       return new Result.Failure<>(e);
     }
+  }
+
+  private String getBasicAuthenticationHeader(final String username, final String password) {
+    String valueToEncode = username + ":" + password;
+    return "Basic " + Base64.getEncoder().encodeToString(valueToEncode.getBytes());
   }
 
   public String toPackageUrls(final SearchResponse.Response.Doc doc) {

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
@@ -71,7 +71,7 @@ public class ComponentReportClient {
 
   public String toPackageUrls(final SearchResponse.Response.Doc doc) {
     try {
-      return new PackageURL("maven", doc.g(), doc.a(), doc.v(), null, null).canonicalize();
+      return new PackageURL("maven", doc.g(), doc.a(), doc.v() != null ? doc.v() : doc.latestVersion(), null, null).canonicalize();
     } catch (MalformedPackageURLException e) {
       throw new McsRuntimeException(e);
     }
@@ -97,6 +97,6 @@ public class ComponentReportClient {
   private boolean matches(final PackageURL packageURL, final SearchResponse.Response.Doc doc) {
     return Objects.equals(packageURL.getNamespace(), doc.g()) &&
         Objects.equals(packageURL.getName(), doc.a()) &&
-        Objects.equals(packageURL.getVersion(), doc.v());
+        Objects.equals(packageURL.getVersion(), doc.v() != null ? doc.v() : doc.latestVersion());
   }
 }

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportClient.java
@@ -36,11 +36,7 @@ public class ComponentReportClient {
   public Result<ComponentReportResponse> search(final List<String> coordinates) {
     var purls = coordinates.stream().map(purl -> "\"" + purl + "\"").collect(Collectors.joining(","));
 
-    var json = """
-            {
-              "coordinates" : [%s]
-            }
-            """;
+    var json = "{\"coordinates\" : [%s]}";
 
     var builder = HttpRequest.newBuilder()
     .version(HttpClient.Version.HTTP_1_1)

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportResponse.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportResponse.java
@@ -2,7 +2,7 @@ package it.mulders.mcs.search.vulnerability;
 
 public record ComponentReportResponse(ComponentReport[] componentReports) {
     public record ComponentReport(String coordinates, String reference, ComponentReportVulnerability[] vulnerabilities) {
-        public record ComponentReportVulnerability(String id, String displayName, String title) {
+        public record ComponentReportVulnerability(String id, String title, double cvssScore) {
         }
     }
 }

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportResponse.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportResponse.java
@@ -1,14 +1,14 @@
 package it.mulders.mcs.search.vulnerability;
 
-import java.util.Arrays;
 import java.util.Comparator;
+import java.util.stream.Stream;
 
 public record ComponentReportResponse(ComponentReport[] componentReports) {
     public record ComponentReport(String coordinates, String reference, ComponentReportVulnerability[] vulnerabilities) {
         public ComponentReportVulnerability[] vulnerabilitiesSortedByCvssScore() {
-            ComponentReportVulnerability[] sorted = Arrays.copyOf(vulnerabilities, vulnerabilities.length);
-            Arrays.sort(sorted, Comparator.comparingDouble(ComponentReportVulnerability::cvssScore).reversed());
-            return sorted;
+            return Stream.of(vulnerabilities)
+                .sorted(Comparator.comparingDouble(ComponentReportVulnerability::cvssScore).reversed())
+                .toArray(ComponentReportVulnerability[]::new);
         }
 
         public record ComponentReportVulnerability(String id, String title, Double cvssScore, String reference) {

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportResponse.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportResponse.java
@@ -1,0 +1,8 @@
+package it.mulders.mcs.search.vulnerability;
+
+public record ComponentReportResponse(ComponentReport[] componentReports) {
+    public record ComponentReport(String coordinates, String reference, ComponentReportVulnerability[] vulnerabilities) {
+        public record ComponentReportVulnerability(String id, String displayName, String title) {
+        }
+    }
+}

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportResponse.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportResponse.java
@@ -1,8 +1,17 @@
 package it.mulders.mcs.search.vulnerability;
 
+import java.util.Arrays;
+import java.util.Comparator;
+
 public record ComponentReportResponse(ComponentReport[] componentReports) {
     public record ComponentReport(String coordinates, String reference, ComponentReportVulnerability[] vulnerabilities) {
-        public record ComponentReportVulnerability(String id, String title, double cvssScore) {
+        public ComponentReportVulnerability[] vulnerabilitiesSortedByCvssScore() {
+            ComponentReportVulnerability[] sorted = Arrays.copyOf(vulnerabilities, vulnerabilities.length);
+            Arrays.sort(sorted, Comparator.comparingDouble(ComponentReportVulnerability::cvssScore).reversed());
+            return sorted;
+        }
+
+        public record ComponentReportVulnerability(String id, String title, Double cvssScore, String reference) {
         }
     }
 }

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandler.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandler.java
@@ -83,7 +83,8 @@ public class ComponentReportResponseBodyHandler implements HttpResponse.BodyHand
     return new ComponentReportResponse.ComponentReport.ComponentReportVulnerability(
         (String) input.get("id"),
         (String) input.get("title"),
-        (double) input.get("cvssScore")
+        (Double) input.get("cvssScore"),
+        (String) input.get("reference")
     );
   }
 }

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandler.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandler.java
@@ -14,8 +14,7 @@ import com.fasterxml.jackson.jr.ob.JSONObjectException;
 import it.mulders.mcs.common.Result;
 import it.mulders.mcs.search.vulnerability.ComponentReportResponse.ComponentReport;
 
-public class ComponentReportResponseBodyHandler implements HttpResponse.BodyHandler<Result<ComponentReportResponse>>
-{
+public class ComponentReportResponseBodyHandler implements HttpResponse.BodyHandler<Result<ComponentReportResponse>> {
   @Override
   public BodySubscriber<Result<ComponentReportResponse>> apply(final ResponseInfo responseInfo) {
     return asObject();
@@ -55,7 +54,7 @@ public class ComponentReportResponseBodyHandler implements HttpResponse.BodyHand
     }
   }
 
-  static ComponentReportResponse constructComponentReportResponse(final List<Object> input){
+  static ComponentReportResponse constructComponentReportResponse(final List<Object> input) {
     return new ComponentReportResponse(input.stream()
         .map(ComponentReportResponseBodyHandler::constructComponentReport)
         .toArray(ComponentReportResponse.ComponentReport[]::new));

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandler.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandler.java
@@ -1,0 +1,89 @@
+package it.mulders.mcs.search.vulnerability;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodySubscriber;
+import java.net.http.HttpResponse.ResponseInfo;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
+import it.mulders.mcs.common.Result;
+import it.mulders.mcs.search.vulnerability.ComponentReportResponse.ComponentReport;
+
+public class ComponentReportResponseBodyHandler implements HttpResponse.BodyHandler<Result<ComponentReportResponse>>
+{
+  @Override
+  public BodySubscriber<Result<ComponentReportResponse>> apply(final ResponseInfo responseInfo) {
+    return asObject();
+  }
+
+  static HttpResponse.BodySubscriber<Result<ComponentReportResponse>> asObject() {
+    var upstream = HttpResponse.BodySubscribers.ofInputStream();
+
+    return HttpResponse.BodySubscribers.mapping(
+        upstream,
+        ComponentReportResponseBodyHandler::toComponentReportResponse
+    );
+  }
+
+  static Result<ComponentReportResponse> toComponentReportResponse(final InputStream inputStream) {
+    try (final InputStream input = inputStream) {
+      var list = JSON.std.listFrom(input);
+      return new Result.Success<>(constructComponentReportResponse(list));
+    } catch (final JsonParseException | JSONObjectException joe) {
+      return new Result.Failure<>(
+          new IllegalStateException(
+              """
+              
+              Error parsing vulnerabilities for supplied component.  This may be a temporary failure from ossindex.sonatype.org.
+              If the problem persists, please open a conversation at
+              
+                  https://github.com/mthmulders/mcs/discussions
+              
+              Make sure to at least provide your invocation of mcs and the version of mcs you're using.
+              """
+          )
+      );
+    } catch (final IOException ioe) {
+      return new Result.Failure<>(
+          new IllegalStateException("Error processing response: %s%n".formatted(ioe.getLocalizedMessage()))
+      );
+    }
+  }
+
+  static ComponentReportResponse constructComponentReportResponse(final List<Object> input){
+    return new ComponentReportResponse(input.stream()
+        .map(ComponentReportResponseBodyHandler::constructComponentReport)
+        .toArray(ComponentReportResponse.ComponentReport[]::new));
+  }
+
+  private static ComponentReportResponse.ComponentReport constructComponentReport(final Object input) {
+    Map<String, Object> map = (Map<String, Object>) input;
+
+    return new ComponentReport(
+        (String) map.get("coordinates"),
+        (String) map.get("reference"),
+        constructComponentReportVulnerabilities((List<Map<String, Object>>) map.get("vulnerabilities"))
+    );
+  }
+
+  private static ComponentReportResponse.ComponentReport.ComponentReportVulnerability[] constructComponentReportVulnerabilities(
+      List<Map<String, Object>> input) {
+    return input.stream()
+        .map(ComponentReportResponseBodyHandler::constructComponentReportVulnerability)
+        .toArray(ComponentReportResponse.ComponentReport.ComponentReportVulnerability[]::new);
+  }
+
+  private static ComponentReportResponse.ComponentReport.ComponentReportVulnerability constructComponentReportVulnerability(
+      final Map<String, Object> input) {
+    return new ComponentReportResponse.ComponentReport.ComponentReportVulnerability(
+        (String) input.get("id"),
+        (String) input.get("displayName"),
+        (String) input.get("title")
+    );
+  }
+}

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandler.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandler.java
@@ -82,8 +82,8 @@ public class ComponentReportResponseBodyHandler implements HttpResponse.BodyHand
       final Map<String, Object> input) {
     return new ComponentReportResponse.ComponentReport.ComponentReportVulnerability(
         (String) input.get("id"),
-        (String) input.get("displayName"),
-        (String) input.get("title")
+        (String) input.get("title"),
+        (double) input.get("cvssScore")
     );
   }
 }

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportVulnerabilitySeverity.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportVulnerabilitySeverity.java
@@ -1,0 +1,38 @@
+package it.mulders.mcs.search.vulnerability;
+
+/**
+ * Based on NVD Vulnerability Severity Ratings. Refer to NVD <a href="https://nvd.nist.gov/vuln-metrics/cvss">site</a>.
+ */
+public enum ComponentReportVulnerabilitySeverity {
+  CRITICAL("Critical", 9.0),
+  HIGH ("High", 7.0),
+  MEDIUM("Medium", 4.0),
+  LOW("Low", 0.1),
+  NONE("None", 0.0);
+
+  ComponentReportVulnerabilitySeverity(String text, Double score) {
+    this.text = text;
+    this.score = score;
+  }
+
+  private final String text;
+  private final Double score;
+
+  public static String getText(Double score) {
+    if (score.compareTo(CRITICAL.score) >= 0) {
+      return CRITICAL.text;
+    }
+    else if (score.compareTo(HIGH.score) >= 0) {
+      return HIGH.text;
+    }
+    else if (score.compareTo(MEDIUM.score) >= 0) {
+      return MEDIUM.text;
+    }
+    else if (score.compareTo(LOW.score) >= 0) {
+      return LOW.text;
+    }
+    else {
+      return NONE.text;
+    }
+  }
+}

--- a/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportVulnerabilitySeverity.java
+++ b/src/main/java/it/mulders/mcs/search/vulnerability/ComponentReportVulnerabilitySeverity.java
@@ -21,17 +21,13 @@ public enum ComponentReportVulnerabilitySeverity {
   public static String getText(Double score) {
     if (score.compareTo(CRITICAL.score) >= 0) {
       return CRITICAL.text;
-    }
-    else if (score.compareTo(HIGH.score) >= 0) {
+    } else if (score.compareTo(HIGH.score) >= 0) {
       return HIGH.text;
-    }
-    else if (score.compareTo(MEDIUM.score) >= 0) {
+    } else if (score.compareTo(MEDIUM.score) >= 0) {
       return MEDIUM.text;
-    }
-    else if (score.compareTo(LOW.score) >= 0) {
+    } else if (score.compareTo(LOW.score) >= 0) {
       return LOW.text;
-    }
-    else {
+    } else {
       return NONE.text;
     }
   }

--- a/src/test/java/it/mulders/mcs/cli/CliTest.java
+++ b/src/test/java/it/mulders/mcs/cli/CliTest.java
@@ -49,6 +49,13 @@ class CliTest implements WithAssertions {
 
             verifySearchExecution(query, "search", "--format", "gradle-short", "test");
         }
+
+        @Test
+        void accepts_show_vulnerabilities_parameter() {
+            var query = SearchQuery.search("test").build();
+
+            verifySearchExecution(query, "search", "--show-vulnerabilities", "test");
+        }
     }
 
     @Nested

--- a/src/test/java/it/mulders/mcs/search/SearchCommandHandlerTest.java
+++ b/src/test/java/it/mulders/mcs/search/SearchCommandHandlerTest.java
@@ -50,7 +50,7 @@ class SearchCommandHandlerTest implements WithAssertions {
         }
     };
 
-    private final SearchCommandHandler handler = new SearchCommandHandler(outputPrinter, searchClient);
+    private final SearchCommandHandler handler = new SearchCommandHandler(outputPrinter, false, searchClient, null);
 
     @Nested
     @DisplayName("Wildcard search")

--- a/src/test/java/it/mulders/mcs/search/printer/CoordinatePrinterTest.java
+++ b/src/test/java/it/mulders/mcs/search/printer/CoordinatePrinterTest.java
@@ -1,15 +1,20 @@
 package it.mulders.mcs.search.printer;
 
-import it.mulders.mcs.search.SearchQuery;
-import it.mulders.mcs.search.SearchResponse;
-import org.assertj.core.api.WithAssertions;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.stream.Stream;
+
+import it.mulders.mcs.search.SearchQuery;
+import it.mulders.mcs.search.SearchResponse;
+import it.mulders.mcs.search.vulnerability.ComponentReportResponse.ComponentReport;
+import it.mulders.mcs.search.vulnerability.ComponentReportResponse.ComponentReport.ComponentReportVulnerability;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class CoordinatePrinterTest implements WithAssertions {
 
@@ -92,5 +97,91 @@ class CoordinatePrinterTest implements WithAssertions {
         var xml = buffer.toString();
 
         assertThat(xml).isEqualToIgnoringWhitespace(expected);
+    }
+
+
+    @Nested
+    @DisplayName("CoordinatePrinter with one vulnerabilities")
+    class CoordinatePrinterWithOneVulnerabilityTest {
+        private static final SearchQuery QUERY_DEPENDENCY_WITH_ONE_VULNERABILITY = SearchQuery.search("org.apache.shiro:shiro-web").build();
+        private static final SearchResponse.Response RESPONSE_WITH_ONE_VULNERABILITY =
+            new SearchResponse.Response(1, 0, new SearchResponse.Response.Doc[]{
+                new SearchResponse.Response.Doc(
+                    "org.apache.shiro:shiro-web:1.10.0",
+                    "org.apache.shiro",
+                    "shiro-web",
+                    "1.10.0",
+                    null,
+                    "jar",
+                    1630022910000L,
+                    new ComponentReport(
+                        "pkg:maven/org.apache.shiro/shiro-web@1.10.0",
+                        "https://ossindex.sonatype.org/component/pkg:maven/org.apache.shiro/shiro-web@1.10.0?utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3",
+                        new ComponentReportVulnerability[] {
+                            new ComponentReportVulnerability("CVE-2023-34478", "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')", 9.8)
+                        }
+                    )
+                )
+            });
+        private static final String POM_XML_DEPENDENCY_OUTPUT_WITH_ONE_VULNERABILITY = """
+            <dependency>
+                <groupId>org.apache.shiro</groupId>
+                <artifactId>shiro-web</artifactId>
+                <version>1.10.0</version>
+            </dependency>
+            
+            Found 1 vulnerability
+            """;
+
+        @Test
+        void should_print_vulnerability_text() {
+            CoordinatePrinter printer = new PomXmlOutput();
+            printer.print(QUERY_DEPENDENCY_WITH_ONE_VULNERABILITY, RESPONSE_WITH_ONE_VULNERABILITY, new PrintStream(buffer));
+            var xml = buffer.toString();
+            assertThat(xml).isEqualToIgnoringWhitespace(POM_XML_DEPENDENCY_OUTPUT_WITH_ONE_VULNERABILITY);
+        }
+    }
+
+    @Nested
+    @DisplayName("CoordinatePrinter with multiple vulnerabilities")
+    class CoordinatePrinterWithMultipleVulnerabilitiesTest {
+        private static final SearchQuery QUERY_DEPENDENCY_WITH_MULTIPLE_VULNERABILITIES = SearchQuery.search("org.apache.shiro:shiro-web").build();
+        private static final SearchResponse.Response RESPONSE_WITH_MULTIPLE_VULNERABILITIES =
+            new SearchResponse.Response(1, 0, new SearchResponse.Response.Doc[]{
+                new SearchResponse.Response.Doc(
+                    "org.apache.shiro:shiro-web:1.9.0",
+                    "org.apache.shiro",
+                    "shiro-web",
+                    "1.9.0",
+                    null,
+                    "jar",
+                    1630022910000L,
+                    new ComponentReport(
+                        "pkg:maven/org.apache.shiro/shiro-web@1.9.0",
+                        "https://ossindex.sonatype.org/component/pkg:maven/org.apache.shiro/shiro-web@1.9.0?utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3",
+                        new ComponentReportVulnerability[] {
+                            new ComponentReportVulnerability("CVE-2023-34478", "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')", 9.8),
+                            new ComponentReportVulnerability("CVE-2022-40664", "CWE-287: Improper Authentication", 9.8)
+                        }
+                    )
+                )
+            });
+        private static final String POM_XML_DEPENDENCY_OUTPUT_WITH_MULTIPLE_VULNERABILITY = """
+            <dependency>
+                <groupId>org.apache.shiro</groupId>
+                <artifactId>shiro-web</artifactId>
+                <version>1.9.0</version>
+            </dependency>
+            
+            Found 2 vulnerabilities
+            """;
+
+        @Test
+        void should_print_vulnerability_text() {
+            CoordinatePrinter printer = new PomXmlOutput();
+            printer.print(QUERY_DEPENDENCY_WITH_MULTIPLE_VULNERABILITIES, RESPONSE_WITH_MULTIPLE_VULNERABILITIES, new PrintStream(buffer));
+            var xml = buffer.toString();
+            assertThat(xml).isEqualToIgnoringWhitespace(POM_XML_DEPENDENCY_OUTPUT_WITH_MULTIPLE_VULNERABILITY);
+        }
     }
 }

--- a/src/test/java/it/mulders/mcs/search/printer/CoordinatePrinterTest.java
+++ b/src/test/java/it/mulders/mcs/search/printer/CoordinatePrinterTest.java
@@ -116,10 +116,10 @@ class CoordinatePrinterTest implements WithAssertions {
                     1630022910000L,
                     new ComponentReport(
                         "pkg:maven/org.apache.shiro/shiro-web@1.9.0",
-                        "https://ossindex.sonatype.org/component/pkg:maven/org.apache.shiro/shiro-web@1.9.0?utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3",
+                        "https://ossindex.sonatype.org/component/pkg:maven/org.apache.shiro/shiro-web@1.9.0",
                         new ComponentReportVulnerability[] {
-                            new ComponentReportVulnerability("CVE-2023-34478", "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')", 9.8, "https://ossindex.sonatype.org/vulnerability/CVE-2023-34478?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3"),
-                            new ComponentReportVulnerability("CVE-2022-40664", "CWE-287: Improper Authentication", 9.8, "https://ossindex.sonatype.org/vulnerability/CVE-2022-40664?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3")
+                            new ComponentReportVulnerability("CVE-2023-34478", "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')", 9.8, "https://ossindex.sonatype.org/vulnerability/CVE-2023-34478?component-type=maven&component-name=org.apache.shiro%2Fshiro-web"),
+                            new ComponentReportVulnerability("CVE-2022-40664", "CWE-287: Improper Authentication", 9.8, "https://ossindex.sonatype.org/vulnerability/CVE-2022-40664?component-type=maven&component-name=org.apache.shiro%2Fshiro-web")
                         }
                     )
                 )
@@ -132,8 +132,8 @@ class CoordinatePrinterTest implements WithAssertions {
             </dependency>
             
             Vulnerabilities:
-            CVE-2023-34478 (Critical) - https://ossindex.sonatype.org/vulnerability/CVE-2023-34478?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3
-            CVE-2022-40664 (Critical) - https://ossindex.sonatype.org/vulnerability/CVE-2022-40664?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3
+            CVE-2023-34478 (Critical) - https://ossindex.sonatype.org/vulnerability/CVE-2023-34478?component-type=maven&component-name=org.apache.shiro%2Fshiro-web
+            CVE-2022-40664 (Critical) - https://ossindex.sonatype.org/vulnerability/CVE-2022-40664?component-type=maven&component-name=org.apache.shiro%2Fshiro-web
             """;
 
         @Test

--- a/src/test/java/it/mulders/mcs/search/printer/CoordinatePrinterTest.java
+++ b/src/test/java/it/mulders/mcs/search/printer/CoordinatePrinterTest.java
@@ -1,9 +1,5 @@
 package it.mulders.mcs.search.printer;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.util.stream.Stream;
-
 import it.mulders.mcs.search.SearchQuery;
 import it.mulders.mcs.search.SearchResponse;
 import it.mulders.mcs.search.vulnerability.ComponentReportResponse.ComponentReport;
@@ -15,6 +11,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.stream.Stream;
 
 class CoordinatePrinterTest implements WithAssertions {
 

--- a/src/test/java/it/mulders/mcs/search/printer/CoordinatePrinterTest.java
+++ b/src/test/java/it/mulders/mcs/search/printer/CoordinatePrinterTest.java
@@ -99,54 +99,12 @@ class CoordinatePrinterTest implements WithAssertions {
         assertThat(xml).isEqualToIgnoringWhitespace(expected);
     }
 
-
     @Nested
-    @DisplayName("CoordinatePrinter with one vulnerabilities")
-    class CoordinatePrinterWithOneVulnerabilityTest {
-        private static final SearchQuery QUERY_DEPENDENCY_WITH_ONE_VULNERABILITY = SearchQuery.search("org.apache.shiro:shiro-web").build();
-        private static final SearchResponse.Response RESPONSE_WITH_ONE_VULNERABILITY =
-            new SearchResponse.Response(1, 0, new SearchResponse.Response.Doc[]{
-                new SearchResponse.Response.Doc(
-                    "org.apache.shiro:shiro-web:1.10.0",
-                    "org.apache.shiro",
-                    "shiro-web",
-                    "1.10.0",
-                    null,
-                    "jar",
-                    1630022910000L,
-                    new ComponentReport(
-                        "pkg:maven/org.apache.shiro/shiro-web@1.10.0",
-                        "https://ossindex.sonatype.org/component/pkg:maven/org.apache.shiro/shiro-web@1.10.0?utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3",
-                        new ComponentReportVulnerability[] {
-                            new ComponentReportVulnerability("CVE-2023-34478", "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')", 9.8)
-                        }
-                    )
-                )
-            });
-        private static final String POM_XML_DEPENDENCY_OUTPUT_WITH_ONE_VULNERABILITY = """
-            <dependency>
-                <groupId>org.apache.shiro</groupId>
-                <artifactId>shiro-web</artifactId>
-                <version>1.10.0</version>
-            </dependency>
-            
-            Found 1 vulnerability
-            """;
-
-        @Test
-        void should_print_vulnerability_text() {
-            CoordinatePrinter printer = new PomXmlOutput();
-            printer.print(QUERY_DEPENDENCY_WITH_ONE_VULNERABILITY, RESPONSE_WITH_ONE_VULNERABILITY, new PrintStream(buffer));
-            var xml = buffer.toString();
-            assertThat(xml).isEqualToIgnoringWhitespace(POM_XML_DEPENDENCY_OUTPUT_WITH_ONE_VULNERABILITY);
-        }
-    }
-
-    @Nested
-    @DisplayName("CoordinatePrinter with multiple vulnerabilities")
+    @DisplayName("CoordinatePrinter with vulnerabilities")
     class CoordinatePrinterWithMultipleVulnerabilitiesTest {
-        private static final SearchQuery QUERY_DEPENDENCY_WITH_MULTIPLE_VULNERABILITIES = SearchQuery.search("org.apache.shiro:shiro-web").build();
-        private static final SearchResponse.Response RESPONSE_WITH_MULTIPLE_VULNERABILITIES =
+        private static final SearchQuery QUERY_DEPENDENCY_WITH_VULNERABILITIES =
+            SearchQuery.search("org.apache.shiro:shiro-web").build();
+        private static final SearchResponse.Response RESPONSE_WITH_VULNERABILITIES =
             new SearchResponse.Response(1, 0, new SearchResponse.Response.Doc[]{
                 new SearchResponse.Response.Doc(
                     "org.apache.shiro:shiro-web:1.9.0",
@@ -160,28 +118,30 @@ class CoordinatePrinterTest implements WithAssertions {
                         "pkg:maven/org.apache.shiro/shiro-web@1.9.0",
                         "https://ossindex.sonatype.org/component/pkg:maven/org.apache.shiro/shiro-web@1.9.0?utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3",
                         new ComponentReportVulnerability[] {
-                            new ComponentReportVulnerability("CVE-2023-34478", "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')", 9.8),
-                            new ComponentReportVulnerability("CVE-2022-40664", "CWE-287: Improper Authentication", 9.8)
+                            new ComponentReportVulnerability("CVE-2023-34478", "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')", 9.8, "https://ossindex.sonatype.org/vulnerability/CVE-2023-34478?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3"),
+                            new ComponentReportVulnerability("CVE-2022-40664", "CWE-287: Improper Authentication", 9.8, "https://ossindex.sonatype.org/vulnerability/CVE-2022-40664?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3")
                         }
                     )
                 )
             });
-        private static final String POM_XML_DEPENDENCY_OUTPUT_WITH_MULTIPLE_VULNERABILITY = """
+        private static final String POM_XML_DEPENDENCY_OUTPUT_WITH_VULNERABILITIES = """
             <dependency>
                 <groupId>org.apache.shiro</groupId>
                 <artifactId>shiro-web</artifactId>
                 <version>1.9.0</version>
             </dependency>
             
-            Found 2 vulnerabilities
+            Vulnerabilities:
+            CVE-2023-34478 (Critical) - https://ossindex.sonatype.org/vulnerability/CVE-2023-34478?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3
+            CVE-2022-40664 (Critical) - https://ossindex.sonatype.org/vulnerability/CVE-2022-40664?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3
             """;
 
         @Test
         void should_print_vulnerability_text() {
             CoordinatePrinter printer = new PomXmlOutput();
-            printer.print(QUERY_DEPENDENCY_WITH_MULTIPLE_VULNERABILITIES, RESPONSE_WITH_MULTIPLE_VULNERABILITIES, new PrintStream(buffer));
+            printer.print(QUERY_DEPENDENCY_WITH_VULNERABILITIES, RESPONSE_WITH_VULNERABILITIES, new PrintStream(buffer));
             var xml = buffer.toString();
-            assertThat(xml).isEqualToIgnoringWhitespace(POM_XML_DEPENDENCY_OUTPUT_WITH_MULTIPLE_VULNERABILITY);
+            assertThat(xml).isEqualToIgnoringWhitespace(POM_XML_DEPENDENCY_OUTPUT_WITH_VULNERABILITIES);
         }
     }
 }

--- a/src/test/java/it/mulders/mcs/search/printer/TabularOutputPrinterTest.java
+++ b/src/test/java/it/mulders/mcs/search/printer/TabularOutputPrinterTest.java
@@ -254,7 +254,8 @@ class TabularOutputPrinterTest implements WithAssertions {
                     "pkg:maven/org.apache.shiro/shiro-web@1.10.0",
                     "https://ossindex.sonatype.org/component/pkg:maven/org.apache.shiro/shiro-web@1.10.0?utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3",
                     new ComponentReportVulnerability[] {
-                        new ComponentReportVulnerability("CVE-2023-34478", "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')", 9.8, "https://ossindex.sonatype.org/vulnerability/CVE-2023-34478?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3")
+                        new ComponentReportVulnerability("CVE-2023-34478", "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')", 9.8, "https://ossindex.sonatype.org/vulnerability/CVE-2023-34478?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3"),
+                        new ComponentReportVulnerability("CVE-2020-13933", "[CVE-2020-13933] CWE-287: Improper Authentication", 7.5, "https://ossindex.sonatype.org/vulnerability/CVE-2020-13933?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3")
                     }
                 )
             )
@@ -267,6 +268,6 @@ class TabularOutputPrinterTest implements WithAssertions {
         // Assert
         var table = buffer.toString();
         assertThat(table).contains("Vulnerabilities");
-        assertThat(table).contains("Found 1 vulnerability");
+        assertThat(table).contains("1 Critical, 1 High");
     }
 }

--- a/src/test/java/it/mulders/mcs/search/printer/TabularOutputPrinterTest.java
+++ b/src/test/java/it/mulders/mcs/search/printer/TabularOutputPrinterTest.java
@@ -1,11 +1,5 @@
 package it.mulders.mcs.search.printer;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-
 import it.mulders.mcs.search.SearchQuery;
 import it.mulders.mcs.search.SearchResponse;
 import it.mulders.mcs.search.vulnerability.ComponentReportResponse.ComponentReport;
@@ -14,6 +8,12 @@ import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class TabularOutputPrinterTest implements WithAssertions {

--- a/src/test/java/it/mulders/mcs/search/printer/TabularOutputPrinterTest.java
+++ b/src/test/java/it/mulders/mcs/search/printer/TabularOutputPrinterTest.java
@@ -254,7 +254,7 @@ class TabularOutputPrinterTest implements WithAssertions {
                     "pkg:maven/org.apache.shiro/shiro-web@1.10.0",
                     "https://ossindex.sonatype.org/component/pkg:maven/org.apache.shiro/shiro-web@1.10.0?utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3",
                     new ComponentReportVulnerability[] {
-                        new ComponentReportVulnerability("CVE-2023-34478", "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')", 9.8)
+                        new ComponentReportVulnerability("CVE-2023-34478", "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')", 9.8, "https://ossindex.sonatype.org/vulnerability/CVE-2023-34478?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3")
                     }
                 )
             )

--- a/src/test/java/it/mulders/mcs/search/printer/TabularOutputPrinterTest.java
+++ b/src/test/java/it/mulders/mcs/search/printer/TabularOutputPrinterTest.java
@@ -252,10 +252,10 @@ class TabularOutputPrinterTest implements WithAssertions {
                 1630022910000L,
                 new ComponentReport(
                     "pkg:maven/org.apache.shiro/shiro-web@1.10.0",
-                    "https://ossindex.sonatype.org/component/pkg:maven/org.apache.shiro/shiro-web@1.10.0?utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3",
+                    "https://ossindex.sonatype.org/component/pkg:maven/org.apache.shiro/shiro-web@1.10.0",
                     new ComponentReportVulnerability[] {
-                        new ComponentReportVulnerability("CVE-2023-34478", "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')", 9.8, "https://ossindex.sonatype.org/vulnerability/CVE-2023-34478?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3"),
-                        new ComponentReportVulnerability("CVE-2020-13933", "[CVE-2020-13933] CWE-287: Improper Authentication", 7.5, "https://ossindex.sonatype.org/vulnerability/CVE-2020-13933?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3")
+                        new ComponentReportVulnerability("CVE-2023-34478", "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')", 9.8, "https://ossindex.sonatype.org/vulnerability/CVE-2023-34478?component-type=maven&component-name=org.apache.shiro%2Fshiro-web"),
+                        new ComponentReportVulnerability("CVE-2020-13933", "[CVE-2020-13933] CWE-287: Improper Authentication", 7.5, "https://ossindex.sonatype.org/vulnerability/CVE-2020-13933?component-type=maven&component-name=org.apache.shiro%2Fshiro-web")
                     }
                 )
             )

--- a/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportClientIT.java
+++ b/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportClientIT.java
@@ -1,0 +1,113 @@
+package it.mulders.mcs.search.vulnerability;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ConnectException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import it.mulders.mcs.common.Result;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.badRequest;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@WireMockTest
+class ComponentReportClientIT implements WithAssertions {
+  String getResourceAsString(final String resourceName) {
+    try (final InputStream input = getClass().getResourceAsStream(resourceName)) {
+      byte[] bytes = input != null ? input.readAllBytes() : new byte[]{};
+        return new String(bytes, StandardCharsets.UTF_8);
+
+    } catch (final IOException ioe) {
+      return fail("Can't load resource %s", resourceName, ioe);
+    }
+  }
+
+  @Nested
+  @DisplayName("ComponentReport with vulnerabilities")
+  class ComponentReportWithVulnerabilitiesTest {
+    @Test
+    void should_parse_response(final WireMockRuntimeInfo wmRuntimeInfo) {
+      // Arrange
+      stubFor(post(urlPathMatching("/api/v3/component-report"))
+          .willReturn(ok(getResourceAsString("/vulnerabilities-component-report-response.json"))));
+
+      // Act
+      var result = new ComponentReportClient(wmRuntimeInfo.getHttpBaseUrl())
+          .search(List.of("pkg:maven/org.apache.shiro/shiro-web@1.9.0"));
+
+      // Assert
+      assertThat(result.value()).isNotNull();
+      assertThat(result.value().componentReports()).hasSize(1);
+      assertThat(result.value().componentReports()[0].vulnerabilities()).hasSize(2);
+
+      var ids = Arrays.stream(result.value().componentReports()[0].vulnerabilities())
+          .map(ComponentReportResponse.ComponentReport.ComponentReportVulnerability::id)
+          .toArray(String[]::new);
+      assertThat(ids).containsOnly("CVE-2022-40664", "CVE-2023-34478");
+    }
+  }
+
+  @Nested
+  @DisplayName("ComponentReport with no vulnerabilities")
+  class ComponentReportWithNoVulnerabilitiesTest {
+    @Test
+    void should_parse_response(final WireMockRuntimeInfo wmRuntimeInfo) {
+      // Arrange
+      stubFor(post(urlPathMatching("/api/v3/component-report"))
+          .willReturn(ok(getResourceAsString("/no-vulnerabilities-component-report-response.json"))));
+
+      // Act
+      var result = new ComponentReportClient(wmRuntimeInfo.getHttpBaseUrl())
+          .search(List.of("pkg:maven/org.codehaus.plexus/plexus-utils@3.4.1"));
+
+      // Assert
+      assertThat(result.value()).isNotNull();
+      assertThat(result.value().componentReports()).hasSize(1);
+      assertThat(result.value().componentReports()[0].vulnerabilities()).isEmpty();
+    }
+  }
+
+  @DisplayName("Error handling")
+  @Nested
+  class ErrorHandlingTest {
+    @Test
+    void should_gracefully_handle_4xx_response(final WireMockRuntimeInfo wmRuntimeInfo) {
+      // Arrange
+      stubFor(post(urlPathMatching("/api/v3/component-report"))
+          .willReturn(badRequest().withBody("Ossindex returned 400, msg: ")));
+
+      // Act
+      var result = new ComponentReportClient(wmRuntimeInfo.getHttpBaseUrl())
+          .search(List.of("pkg:maven/org.codehaus.plexus/plexus-utils@3.4.1"));
+
+      // Assert
+      assertThat(result).isInstanceOf(Result.Failure.class);
+      assertThat(result.cause()).isInstanceOf(IllegalStateException.class);
+      assertThat(result.cause()).hasMessageContaining("https://github.com/mthmulders/mcs/discussions");
+    }
+
+    @Test
+    void should_gracefully_handle_connection_failure() {
+      // Very unlikely there's an HTTP server running there...
+      var result = new ComponentReportClient("http://localhost:21")
+          .search(List.of("pkg:maven/org.codehaus.plexus/plexus-utils@3.4.1"));
+
+      assertThat(result).isInstanceOf(Result.Failure.class);
+      assertThat(result.cause()).isInstanceOf(ConnectException.class);
+    }
+  }
+}

--- a/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportClientIT.java
+++ b/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportClientIT.java
@@ -11,13 +11,13 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import it.mulders.mcs.common.Result;
 import org.assertj.core.api.WithAssertions;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetSystemProperty;
+import org.junitpioneer.jupiter.SetSystemProperty.SetSystemProperties;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.badRequest;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
@@ -41,19 +41,11 @@ class ComponentReportClientIT implements WithAssertions {
   @Nested
   @DisplayName("ComponentReport with vulnerabilities")
   class ComponentReportWithVulnerabilitiesTest {
-    @BeforeEach
-    void setup() {
-      System.setProperty("ossindex.username", "user");
-      System.setProperty("ossindex.password", "pass");
-    }
-
-    @AfterEach
-    void cleanup() {
-      System.clearProperty("ossindex.username");
-      System.clearProperty("ossindex.password");
-    }
-
     @Test
+    @SetSystemProperties({
+        @SetSystemProperty(key = "ossindex.username", value = "user"),
+        @SetSystemProperty(key = "ossindex.password", value = "pass")
+    })
     void should_parse_response(final WireMockRuntimeInfo wmRuntimeInfo) {
       // Arrange
       stubFor(post(urlPathMatching("/api/v3/authorized/component-report"))

--- a/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportClientIT.java
+++ b/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportClientIT.java
@@ -11,6 +11,8 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import it.mulders.mcs.common.Result;
 import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -39,10 +41,23 @@ class ComponentReportClientIT implements WithAssertions {
   @Nested
   @DisplayName("ComponentReport with vulnerabilities")
   class ComponentReportWithVulnerabilitiesTest {
+    @BeforeEach
+    void setup() {
+      System.setProperty("ossindex.username", "user");
+      System.setProperty("ossindex.password", "pass");
+    }
+
+    @AfterEach
+    void cleanup() {
+      System.clearProperty("ossindex.username");
+      System.clearProperty("ossindex.password");
+    }
+
     @Test
     void should_parse_response(final WireMockRuntimeInfo wmRuntimeInfo) {
       // Arrange
-      stubFor(post(urlPathMatching("/api/v3/component-report"))
+      stubFor(post(urlPathMatching("/api/v3/authorized/component-report"))
+          .withBasicAuth("user", "pass")
           .willReturn(ok(getResourceAsString("/vulnerabilities-component-report-response.json"))));
 
       // Act

--- a/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandlerTest.java
+++ b/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandlerTest.java
@@ -1,0 +1,62 @@
+package it.mulders.mcs.search.vulnerability;
+
+import it.mulders.mcs.common.Result;
+import it.mulders.mcs.search.vulnerability.ComponentReportResponse.ComponentReport.ComponentReportVulnerability;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ComponentReportResponseBodyHandlerTest implements WithAssertions {
+  @Test
+  void  parse_component_report_with_vulnerabilities() {
+    // Arrange
+    var input = getClass().getResourceAsStream("/vulnerabilities-component-report-response.json");
+
+    // Act
+    var result = ComponentReportResponseBodyHandler.toComponentReportResponse(input);
+
+    // Assert
+    assertThat(result).isInstanceOf(Result.Success.class);
+    var response = result.value();
+    assertThat(response.componentReports()).hasSize(1);
+    assertThat(response.componentReports()[0].coordinates()).isEqualTo("pkg:maven/org.apache.shiro/shiro-web@1.9.0");
+    assertThat(response.componentReports()[0].reference()).isEqualTo(
+        "https://ossindex.sonatype.org/component/pkg:maven/org.apache.shiro/shiro-web@1.9.0?utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3");
+
+    assertThat(response.componentReports()[0].vulnerabilities()).hasSize(2);
+    assertThat(response.componentReports()[0].vulnerabilities()).contains(
+        new ComponentReportVulnerability(
+            "CVE-2022-40664",
+            "CVE-2022-40664",
+            "[CVE-2022-40664] CWE-287: Improper Authentication"
+        )
+    );
+    assertThat(response.componentReports()[0].vulnerabilities()).contains(
+        new ComponentReportVulnerability(
+            "CVE-2023-34478",
+            "CVE-2023-34478",
+            "[CVE-2023-34478] CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+        )
+    );
+  }
+
+  @Test
+  void  parse_component_report_with_no_vulnerabilities() {
+    // Arrange
+    var input = getClass().getResourceAsStream("/no-vulnerabilities-component-report-response.json");
+
+    // Act
+    var result = ComponentReportResponseBodyHandler.toComponentReportResponse(input);
+
+    // Assert
+    assertThat(result).isInstanceOf(Result.Success.class);
+    var response = result.value();
+    assertThat(response.componentReports()).hasSize(1);
+    assertThat(response.componentReports()[0].coordinates()).isEqualTo("pkg:maven/org.codehaus.plexus/plexus-utils@3.4.1");
+    assertThat(response.componentReports()[0].reference()).isEqualTo(
+        "https://ossindex.sonatype.org/component/pkg:maven/org.codehaus.plexus/plexus-utils@3.4.1?utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3");
+    assertThat(response.componentReports()[0].vulnerabilities()).isEmpty();
+  }
+}

--- a/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandlerTest.java
+++ b/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandlerTest.java
@@ -29,15 +29,15 @@ class ComponentReportResponseBodyHandlerTest implements WithAssertions {
     assertThat(response.componentReports()[0].vulnerabilities()).contains(
         new ComponentReportVulnerability(
             "CVE-2022-40664",
-            "CVE-2022-40664",
-            "[CVE-2022-40664] CWE-287: Improper Authentication"
+            "[CVE-2022-40664] CWE-287: Improper Authentication",
+            9.8
         )
     );
     assertThat(response.componentReports()[0].vulnerabilities()).contains(
         new ComponentReportVulnerability(
             "CVE-2023-34478",
-            "CVE-2023-34478",
-            "[CVE-2023-34478] CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+            "[CVE-2023-34478] CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')",
+            9.8
         )
     );
   }

--- a/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandlerTest.java
+++ b/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandlerTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class ComponentReportResponseBodyHandlerTest implements WithAssertions {
   @Test
-  void  parse_component_report_with_vulnerabilities() {
+  void parse_component_report_with_vulnerabilities() {
     // Arrange
     var input = getClass().getResourceAsStream("/vulnerabilities-component-report-response.json");
 

--- a/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandlerTest.java
+++ b/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandlerTest.java
@@ -23,7 +23,7 @@ class ComponentReportResponseBodyHandlerTest implements WithAssertions {
     assertThat(response.componentReports()).hasSize(1);
     assertThat(response.componentReports()[0].coordinates()).isEqualTo("pkg:maven/org.apache.shiro/shiro-web@1.9.0");
     assertThat(response.componentReports()[0].reference()).isEqualTo(
-        "https://ossindex.sonatype.org/component/pkg:maven/org.apache.shiro/shiro-web@1.9.0?utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3");
+        "https://ossindex.sonatype.org/component/pkg:maven/org.apache.shiro/shiro-web@1.9.0");
 
     assertThat(response.componentReports()[0].vulnerabilities()).hasSize(2);
     assertThat(response.componentReports()[0].vulnerabilities()).contains(
@@ -31,7 +31,7 @@ class ComponentReportResponseBodyHandlerTest implements WithAssertions {
             "CVE-2022-40664",
             "[CVE-2022-40664] CWE-287: Improper Authentication",
             9.8,
-            "https://ossindex.sonatype.org/vulnerability/CVE-2022-40664?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3"
+            "https://ossindex.sonatype.org/vulnerability/CVE-2022-40664?component-type=maven&component-name=org.apache.shiro%2Fshiro-web"
         )
     );
     assertThat(response.componentReports()[0].vulnerabilities()).contains(
@@ -39,7 +39,7 @@ class ComponentReportResponseBodyHandlerTest implements WithAssertions {
             "CVE-2023-34478",
             "[CVE-2023-34478] CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')",
             9.8,
-            "https://ossindex.sonatype.org/vulnerability/CVE-2023-34478?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3"
+            "https://ossindex.sonatype.org/vulnerability/CVE-2023-34478?component-type=maven&component-name=org.apache.shiro%2Fshiro-web"
         )
     );
   }
@@ -58,7 +58,7 @@ class ComponentReportResponseBodyHandlerTest implements WithAssertions {
     assertThat(response.componentReports()).hasSize(1);
     assertThat(response.componentReports()[0].coordinates()).isEqualTo("pkg:maven/org.codehaus.plexus/plexus-utils@3.4.1");
     assertThat(response.componentReports()[0].reference()).isEqualTo(
-        "https://ossindex.sonatype.org/component/pkg:maven/org.codehaus.plexus/plexus-utils@3.4.1?utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3");
+        "https://ossindex.sonatype.org/component/pkg:maven/org.codehaus.plexus/plexus-utils@3.4.1");
     assertThat(response.componentReports()[0].vulnerabilities()).isEmpty();
   }
 }

--- a/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandlerTest.java
+++ b/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandlerTest.java
@@ -45,7 +45,7 @@ class ComponentReportResponseBodyHandlerTest implements WithAssertions {
   }
 
   @Test
-  void  parse_component_report_with_no_vulnerabilities() {
+  void parse_component_report_with_no_vulnerabilities() {
     // Arrange
     var input = getClass().getResourceAsStream("/no-vulnerabilities-component-report-response.json");
 

--- a/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandlerTest.java
+++ b/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportResponseBodyHandlerTest.java
@@ -30,14 +30,16 @@ class ComponentReportResponseBodyHandlerTest implements WithAssertions {
         new ComponentReportVulnerability(
             "CVE-2022-40664",
             "[CVE-2022-40664] CWE-287: Improper Authentication",
-            9.8
+            9.8,
+            "https://ossindex.sonatype.org/vulnerability/CVE-2022-40664?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3"
         )
     );
     assertThat(response.componentReports()[0].vulnerabilities()).contains(
         new ComponentReportVulnerability(
             "CVE-2023-34478",
             "[CVE-2023-34478] CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')",
-            9.8
+            9.8,
+            "https://ossindex.sonatype.org/vulnerability/CVE-2023-34478?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3"
         )
     );
   }

--- a/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportVulnerabilitySeverityTest.java
+++ b/src/test/java/it/mulders/mcs/search/vulnerability/ComponentReportVulnerabilitySeverityTest.java
@@ -1,0 +1,34 @@
+package it.mulders.mcs.search.vulnerability;
+
+import java.util.stream.Stream;
+
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ComponentReportVulnerabilitySeverityTest implements WithAssertions {
+
+  private static Stream<Arguments> scores() {
+    return Stream.of(
+      Arguments.of(9.8, "Critical"),
+      Arguments.of(9.0, "Critical"),
+      Arguments.of(8.0, "High"),
+      Arguments.of(7.0, "High"),
+      Arguments.of(5.0, "Medium"),
+      Arguments.of(4.0, "Medium"),
+      Arguments.of(2.0, "Low"),
+      Arguments.of(0.1, "Low"),
+      Arguments.of(0.0, "None")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("scores")
+  void should_return_correct_severity_for_score(double score, String expectedSeverity) {
+    assertThat(ComponentReportVulnerabilitySeverity.getText(score)).isEqualTo(expectedSeverity);
+  }
+}

--- a/src/test/resources/no-vulnerabilities-component-report-response.json
+++ b/src/test/resources/no-vulnerabilities-component-report-response.json
@@ -2,7 +2,7 @@
   {
     "coordinates": "pkg:maven/org.codehaus.plexus/plexus-utils@3.4.1",
     "description": "A collection of various utility classes to ease working with strings, files, command lines, XML and more.",
-    "reference": "https://ossindex.sonatype.org/component/pkg:maven/org.codehaus.plexus/plexus-utils@3.4.1?utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3",
+    "reference": "https://ossindex.sonatype.org/component/pkg:maven/org.codehaus.plexus/plexus-utils@3.4.1",
     "vulnerabilities": []
   }
 ]

--- a/src/test/resources/no-vulnerabilities-component-report-response.json
+++ b/src/test/resources/no-vulnerabilities-component-report-response.json
@@ -1,0 +1,8 @@
+[
+  {
+    "coordinates": "pkg:maven/org.codehaus.plexus/plexus-utils@3.4.1",
+    "description": "A collection of various utility classes to ease working with strings, files, command lines, XML and more.",
+    "reference": "https://ossindex.sonatype.org/component/pkg:maven/org.codehaus.plexus/plexus-utils@3.4.1?utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3",
+    "vulnerabilities": []
+  }
+]

--- a/src/test/resources/vulnerabilities-component-report-response.json
+++ b/src/test/resources/vulnerabilities-component-report-response.json
@@ -2,7 +2,7 @@
   {
     "coordinates": "pkg:maven/org.apache.shiro/shiro-web@1.9.0",
     "description": "",
-    "reference": "https://ossindex.sonatype.org/component/pkg:maven/org.apache.shiro/shiro-web@1.9.0?utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3",
+    "reference": "https://ossindex.sonatype.org/component/pkg:maven/org.apache.shiro/shiro-web@1.9.0",
     "vulnerabilities": [
       {
         "id": "CVE-2022-40664",
@@ -13,7 +13,7 @@
         "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
         "cwe": "CWE-287",
         "cve": "CVE-2022-40664",
-        "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-40664?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3",
+        "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-40664?component-type=maven&component-name=org.apache.shiro%2Fshiro-web",
         "externalReferences": [
           "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-40664",
           "https://shiro.apache.org/blog/2022/10/10/2022/apache-shiro-1101-released.html",
@@ -31,7 +31,7 @@
         "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
         "cwe": "CWE-22",
         "cve": "CVE-2023-34478",
-        "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2023-34478?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3",
+        "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2023-34478?component-type=maven&component-name=org.apache.shiro%2Fshiro-web",
         "externalReferences": [
           "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-34478",
           "https://lists.apache.org/thread/jowcs5nd4tz5fxwl1mqkqnvyrwwx59qo"

--- a/src/test/resources/vulnerabilities-component-report-response.json
+++ b/src/test/resources/vulnerabilities-component-report-response.json
@@ -1,0 +1,42 @@
+[
+  {
+    "coordinates": "pkg:maven/org.apache.shiro/shiro-web@1.9.0",
+    "description": "",
+    "reference": "https://ossindex.sonatype.org/component/pkg:maven/org.apache.shiro/shiro-web@1.9.0?utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3",
+    "vulnerabilities": [
+      {
+        "id": "CVE-2022-40664",
+        "displayName": "CVE-2022-40664",
+        "title": "[CVE-2022-40664] CWE-287: Improper Authentication",
+        "description": "Apache Shiro before 1.10.0, Authentication Bypass Vulnerability in Shiro when forwarding or including via RequestDispatcher.",
+        "cvssScore": 9.8,
+        "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "cwe": "CWE-287",
+        "cve": "CVE-2022-40664",
+        "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-40664?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3",
+        "externalReferences": [
+          "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-40664",
+          "https://shiro.apache.org/blog/2022/10/10/2022/apache-shiro-1101-released.html",
+          "https://lists.apache.org/thread/loc2ktxng32xpy7lfwxto13k4lvnhjwg",
+          "http://www.openwall.com/lists/oss-security/2022/10/12/1",
+          "https://github.com/advisories/GHSA-45x9-q6vj-cqgq"
+        ]
+      },
+      {
+        "id": "CVE-2023-34478",
+        "displayName": "CVE-2023-34478",
+        "title": "[CVE-2023-34478] CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')",
+        "description": "Apache Shiro, before 1.12.0 or 2.0.0-alpha-3, may be susceptible to a path traversal attack that results in an authentication bypass when used together with APIs or other web frameworks that route requests based on non-normalized requests.\n\nMitigation: Update to Apache Shiro 1.12.0+ or 2.0.0-alpha-3+\n\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2023-34478 for details",
+        "cvssScore": 9.8,
+        "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "cwe": "CWE-22",
+        "cve": "CVE-2023-34478",
+        "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2023-34478?component-type=maven&component-name=org.apache.shiro%2Fshiro-web&utm_source=postmanruntime&utm_medium=integration&utm_content=7.32.3",
+        "externalReferences": [
+          "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-34478",
+          "https://lists.apache.org/thread/jowcs5nd4tz5fxwl1mqkqnvyrwwx59qo"
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Firstly wanted to say thank you for developing such an amazing tool! 

I started to look into issue #22 and this draft PR demonstrates a possible implementation. Any thoughts/ideas/feedback would be most welcome.

The OSS Index Rest [API](https://ossindex.sonatype.org/rest) provides two endpoints for accessing a component report (listing known vulnerabilities). Sadly both endpoints involve rate limiting (I don't know the figures off the top of my head) but the authorized endpoint provides a higher limit. You can register and use an email and api token to authenticate each request. See [instructions](https://ossindex.sonatype.org/doc/api-token).

1. The rest endpoint uses a Package Url to identify a dependency. This is the [specification](https://github.com/package-url/purl-spec) and this is Java [implementation](https://github.com/package-url/packageurl-java) I used.
2. This PR uses the unauthorized endpoint  (and quickly ran into issues with rate limiting). I like the [discussion](https://github.com/mthmulders/mcs/discussions/187) of having a default configuration where oss index credentials could be stored.
3. Example displaying cve ids (didn't make sense to show the "description" as I believe this is intended for html output)
![image](https://github.com/mthmulders/mcs/assets/38332365/c109fc32-661c-41f4-9e81-06e094dcf174)
4. Example displaying reference links (unfortunately the links are quite long)
![image](https://github.com/mthmulders/mcs/assets/38332365/fb3a7d0b-1c14-4e63-bb6d-88f664cbcaef)
5. Example when searching for dependency leads to a direct match
![image](https://github.com/mthmulders/mcs/assets/38332365/38fa4a8f-ff9d-4854-80e8-e095cfb4005a)

Do you already have a solution in mind? Any preference for how vulnerabilities should be displayed?
