### PR TITLE
POC - Make search the default command

### DIFF
--- a/src/main/java/it/mulders/mcs/cli/Cli.java
+++ b/src/main/java/it/mulders/mcs/cli/Cli.java
@@ -5,7 +5,10 @@ import it.mulders.mcs.search.SearchCommandHandler;
 import it.mulders.mcs.search.SearchQuery;
 import it.mulders.mcs.search.printer.CoordinatePrinter;
 import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
 
+import java.util.Objects;
 import java.util.concurrent.Callable;
 
 @CommandLine.Command(
@@ -71,8 +74,17 @@ public class Cli implements Callable<Integer> {
     )
     private boolean showVulnerabilities;
 
+
+    @Spec
+    CommandSpec spec;
+
     @Override
     public Integer call() {
+        if (Objects.isNull(query)) {
+            spec.commandLine().usage(System.err);
+            System.exit(1);
+        }
+
         var combinedQuery = String.join(" ", query);
         System.out.printf("Searching for %s...%n", combinedQuery);
         var searchQuery = SearchQuery.search(combinedQuery)

--- a/src/main/java/it/mulders/mcs/cli/Cli.java
+++ b/src/main/java/it/mulders/mcs/cli/Cli.java
@@ -37,7 +37,7 @@ public class Cli implements Callable<Integer> {
     }
 
     @CommandLine.Parameters(
-        arity = "1..n",
+        arity = "0..n",
         description = {
             "What to search for.",
             "If the search term contains a colon ( : ), it is considered a literal groupId and artifactId",

--- a/src/main/java/it/mulders/mcs/cli/CommandClassFactory.java
+++ b/src/main/java/it/mulders/mcs/cli/CommandClassFactory.java
@@ -17,9 +17,7 @@ public class CommandClassFactory implements CommandLine.IFactory {
     @Override
     @SuppressWarnings("unchecked")
     public <K> K create(Class<K> cls) throws Exception {
-        if (cls == Cli.SearchCommand.class) {
-            return (K) cli.createSearchCommand();
-        } else if (cls == Cli.ClassSearchCommand.class) {
+        if (cls == Cli.ClassSearchCommand.class) {
             return (K) cli.createClassSearchCommand();
         }
 

--- a/src/test/java/it/mulders/mcs/cli/CliTest.java
+++ b/src/test/java/it/mulders/mcs/cli/CliTest.java
@@ -26,35 +26,35 @@ class CliTest implements WithAssertions {
         void delegates_to_handler() {
             var query = SearchQuery.search("test").build();
 
-            verifySearchExecution(query, "search", "test");
+            verifySearchExecution(query, "test");
         }
 
         @Test
         void accepts_space_separated_terms() {
             SearchQuery query = SearchQuery.search("jakarta rs").build();
 
-            verifySearchExecution(query, "search", "jakarta", "rs");
+            verifySearchExecution(query, "jakarta", "rs");
         }
 
         @Test
         void accepts_limit_results_parameter() {
             var query = SearchQuery.search("test").withLimit(3).build();
 
-            verifySearchExecution(query, "search", "--limit", "3", "test");
+            verifySearchExecution(query, "--limit", "3", "test");
         }
 
         @Test
         void accepts_output_type_parameter() {
             var query = SearchQuery.search("test").build();
 
-            verifySearchExecution(query, "search", "--format", "gradle-short", "test");
+            verifySearchExecution(query, "--format", "gradle-short", "test");
         }
 
         @Test
         void accepts_show_vulnerabilities_parameter() {
             var query = SearchQuery.search("test").build();
 
-            verifySearchExecution(query, "search", "--show-vulnerabilities", "test");
+            verifySearchExecution(query, "--show-vulnerabilities", "test");
         }
     }
 

--- a/src/test/java/it/mulders/mcs/cli/CommandClassFactoryTest.java
+++ b/src/test/java/it/mulders/mcs/cli/CommandClassFactoryTest.java
@@ -11,8 +11,8 @@ class CommandClassFactoryTest implements WithAssertions {
     private final CommandClassFactory factory = new CommandClassFactory(cli);
 
     @Test
-    void can_construct_search_command_instance() throws Exception {
-        assertThat(factory.create(Cli.SearchCommand.class)).isNotNull();
+    void can_construct_class_search_command_instance() throws Exception {
+        assertThat(factory.create(Cli.ClassSearchCommand.class)).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
I think #18 is a great idea and worth investigating. The approach taken in this PR is 
1. Remove the `SearchCommand` subcommand.
2. Make the `Cli` class implement `Callable` interface.
3. Move the CommandLine options from `SearchCommand` to `Cli` along with overridden `call` method.  

**Notes**
- With this PR `mcs org.apache.shiro:shiro-web` is basically the same as `mcs search org.apache.shiro:shiro-web` 
- Can still use subcommands e.g. `mcs class-search CommandLine` will still work (as will future subcommands)
- The main difference I noticed was before `mcs --help` would print the help for the subcommands (search and class search), now it will print the help, which includes all the search flags e.g.  `--show-vulnerabilities`, `limit` etc