### PR TITLE
feat: Use 'search' as default command when not specified

### DIFF
--- a/src/main/java/it/mulders/mcs/App.java
+++ b/src/main/java/it/mulders/mcs/App.java
@@ -13,11 +13,11 @@ public class App {
 
     // Visible for testing
     static int doMain(final String... originalArgs) {
-        return doMain(new Cli(), originalArgs);
+        return doMain(new Cli(), new SystemPropertyLoader(), originalArgs);
     }
 
-    static int doMain(final Cli cli, final String... originalArgs) {
-        System.setProperties(new SystemPropertyLoader().getProperties());
+    static int doMain(final Cli cli, final SystemPropertyLoader systemPropertyLoader, final String... originalArgs) {
+        System.setProperties(systemPropertyLoader.getProperties());
         var program = new CommandLine(cli, new CommandClassFactory(cli))
                 .setExecutionExceptionHandler(new McsExecutionExceptionHandler());
 

--- a/src/main/java/it/mulders/mcs/App.java
+++ b/src/main/java/it/mulders/mcs/App.java
@@ -12,11 +12,37 @@ public class App {
     }
 
     // Visible for testing
-    static int doMain(final String... args) {
+    static int doMain(final String... originalArgs) {
         System.setProperties(new SystemPropertyLoader().getProperties());
-        var cli = new Cli();
         var program = new CommandLine(cli, new CommandClassFactory(cli))
                 .setExecutionExceptionHandler(new McsExecutionExceptionHandler());
+
+        var args = isInvocationWithoutSearchCommand(program, originalArgs)
+            ? prependSearchCommandToArgs(originalArgs)
+            : originalArgs;
+
         return program.execute(args);
+    }
+
+    static boolean isInvocationWithoutSearchCommand(CommandLine program, String... args) {
+        try {
+            program.parseArgs(args);
+            return false;
+        } catch (CommandLine.ParameterException pe1) {
+            try {
+                program.parseArgs(prependSearchCommandToArgs(args));
+                return true;
+            } catch (CommandLine.ParameterException pe2) {
+                return false;
+            }
+        }
+    }
+
+    static String[] prependSearchCommandToArgs(String... originalArgs) {
+        var args = new String[originalArgs.length + 1];
+        args[0] = "search";
+        System.arraycopy(originalArgs, 0, args, 1, originalArgs.length);
+
+        return args;
     }
 }

--- a/src/main/java/it/mulders/mcs/App.java
+++ b/src/main/java/it/mulders/mcs/App.java
@@ -13,6 +13,10 @@ public class App {
 
     // Visible for testing
     static int doMain(final String... originalArgs) {
+        return doMain(new Cli(), originalArgs);
+    }
+
+    static int doMain(final Cli cli, final String... originalArgs) {
         System.setProperties(new SystemPropertyLoader().getProperties());
         var program = new CommandLine(cli, new CommandClassFactory(cli))
                 .setExecutionExceptionHandler(new McsExecutionExceptionHandler());

--- a/src/main/java/it/mulders/mcs/cli/SystemPropertyLoader.java
+++ b/src/main/java/it/mulders/mcs/cli/SystemPropertyLoader.java
@@ -20,26 +20,24 @@ public class SystemPropertyLoader {
             "mcs.config"
     );
 
-    private final Properties properties;
+    private final Properties properties = new Properties();;
 
     public SystemPropertyLoader() {
         this(MCS_PROPERTIES_FILE);
     }
 
     protected SystemPropertyLoader(final Path source) {
-        var input = new Properties();
+        properties.putAll(System.getProperties());
 
         if (Files.exists(source) && Files.isRegularFile(source)) {
+            var input = new Properties();
             try (var reader = Files.newBufferedReader(source)) {
                 input.load(reader);
+                properties.putAll(input);
             } catch (IOException ioe) {
                 System.err.printf("Failed to load %s: %s%n", source, ioe.getLocalizedMessage());
             }
         }
-
-        this.properties = new Properties();
-        properties.putAll(System.getProperties());
-        properties.putAll(input);
     }
 
     public Properties getProperties() {

--- a/src/test/java/it/mulders/mcs/AppIT.java
+++ b/src/test/java/it/mulders/mcs/AppIT.java
@@ -1,10 +1,13 @@
 package it.mulders.mcs;
 
 import it.mulders.mcs.cli.Cli;
+import it.mulders.mcs.cli.SystemPropertyLoader;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
 
 import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOut;
 
@@ -47,6 +50,22 @@ class AppIT implements WithAssertions  {
 
     @Test
     void runs_without_search_command_specified() {
-        assertThat(App.doMain(command, "info.picocli:picocli")).isEqualTo(0);
+        assertThat(App.doMain(command, new SystemPropertyLoader(), "info.picocli:picocli")).isEqualTo(0);
+    }
+
+    @Test
+    void should_load_additional_system_properties() {
+        var loader = new SystemPropertyLoader() {
+            @Override
+            public Properties getProperties() {
+                var tmp = super.getProperties();
+                tmp.put("example", "value");
+                return tmp;
+            }
+        };
+
+        App.doMain(command, loader, "info.picocli:picocli");
+
+        assertThat(System.getProperty("example")).isEqualTo("value");
     }
 }

--- a/src/test/java/it/mulders/mcs/AppIT.java
+++ b/src/test/java/it/mulders/mcs/AppIT.java
@@ -1,5 +1,6 @@
 package it.mulders.mcs;
 
+import it.mulders.mcs.cli.Cli;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -9,6 +10,25 @@ import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOut;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class AppIT implements WithAssertions  {
+    private final Cli command = new Cli() {
+        @Override
+        public SearchCommand createSearchCommand() {
+            return new SearchCommand() {
+                public Integer call() {
+                    return 0;
+                }
+            };
+        }
+
+        @Override
+        public ClassSearchCommand createClassSearchCommand() {
+            return new ClassSearchCommand() {
+                public Integer call() {
+                    return 0;
+                }
+            };
+        }
+    };
     @Test
     void should_show_version() throws Exception {
         var output = tapSystemOut(() -> App.doMain("-V"));
@@ -23,5 +43,10 @@ class AppIT implements WithAssertions  {
     @Test
     void should_exit_nonzero_on_wrong_invocation() {
         assertThat(App.doMain("--does-not-exist")).isNotEqualTo(0);
+    }
+
+    @Test
+    void runs_without_search_command_specified() {
+        assertThat(App.doMain(command, "info.picocli:picocli")).isEqualTo(0);
     }
 }

--- a/src/test/java/it/mulders/mcs/AppTest.java
+++ b/src/test/java/it/mulders/mcs/AppTest.java
@@ -1,0 +1,55 @@
+package it.mulders.mcs;
+
+import it.mulders.mcs.cli.Cli;
+import it.mulders.mcs.cli.CommandClassFactory;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AppTest implements WithAssertions {
+    @Nested
+    class PrependSearchCommandToArgs {
+        @Test
+        void should_prepend_search_to_command_line_args() {
+            assertThat(App.prependSearchCommandToArgs("info.picocli:picocli"))
+                    .isEqualTo(new String[] { "search", "info.picocli:picocli"});
+            assertThat(App.prependSearchCommandToArgs("-h"))
+                    .isEqualTo(new String[] { "search", "-h"});
+            assertThat(App.prependSearchCommandToArgs())
+                    .isEqualTo(new String[] { "search" });
+        }
+    }
+
+    @Nested
+    class IsInvocationWithoutSearchCommand {
+        private final Cli cli = new Cli();
+        private final CommandLine program = new CommandLine(cli, new CommandClassFactory(cli));
+
+        @Test
+        void should_detect_when_search_command_is_not_present() {
+            assertThat(App.isInvocationWithoutSearchCommand(program, "info.picocli:picocli")).isTrue();
+            assertThat(App.isInvocationWithoutSearchCommand(program, "info.picocli", "picocli")).isTrue();
+            assertThat(App.isInvocationWithoutSearchCommand(program, "info.picocli", "picocli",  "4.7.5")).isTrue();
+        }
+
+        @Test
+        void should_detect_when_search_command_is_present() {
+            assertThat(App.isInvocationWithoutSearchCommand(program, "search", "info.picocli:picocli")).isFalse();
+            assertThat(App.isInvocationWithoutSearchCommand(program, "search", "--help")).isFalse();
+        }
+
+        @Test
+        void invoking_help_is_not_invoking_search_help() {
+            assertThat(App.isInvocationWithoutSearchCommand(program, "--help")).isFalse();
+        }
+
+        @Test
+        void invoking_help_is_not_invoking_search_version() {
+            assertThat(App.isInvocationWithoutSearchCommand(program, "-V")).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
This is a backwards-compatible implementation of #18. It tries to parse the user-supplied arguments. When that fails, it tries again, with `search` prepended. If that succeeds, normal execution is resumed.

I'm not sure this is the recommended PicoCLI approach, but it works, and it doesn't break existing usage patterns or finger gymnastics users may have developed.