### PR TITLE
chore(build): Refactor GitHub artifact handling

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4.1.0
 
       - name: Check out repository
         uses: actions/checkout@v4.1.1
@@ -120,7 +120,7 @@ jobs:
         run: git checkout ${{ steps.head.outputs.content }}
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4.1.0
 
       - name: Cache Maven packages
         uses: actions/cache@v3.3.2

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -96,7 +96,7 @@ jobs:
         run: mvn -B -Pdist package -DskipTests
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: artifacts
           path: |
@@ -136,7 +136,7 @@ jobs:
 
       - name: Capture JReleaser output
         if: always()
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: jreleaser-release-output
           retention-days: 7

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -121,6 +121,16 @@ jobs:
 
       - name: Download all build artifacts
         uses: actions/download-artifact@v4.1.0
+        with:
+          path: /tmp/artifacts
+
+      - name: Move build artifacts to correct folder
+        run: |
+          targets=("ubuntu-latest" "macOS-latest" "macOS-arm64-latest" "windows-latest")
+          
+          mkdir -p target/distributions
+          
+          find /tmp/artifacts/ -name "mcs*" -exec mv -v {} target/distributions/ \;
 
       - name: Cache Maven packages
         uses: actions/cache@v3.3.2

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4.0.0
         with:
-          name: artifacts
+          name: artifacts-${{ matrix.os }}
           path: |
             target/distributions/*.zip
             target/distributions/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           echo $NEXT_VERSION > NEXT_VERSION
 
       - name: Upload version files
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: artifacts
           path: |
@@ -155,7 +155,7 @@ jobs:
         run: mvn -B -Pdist package -DskipTests
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: artifacts
           path: |
@@ -236,7 +236,7 @@ jobs:
 
       - name: Capture JReleaser output
         if: always()
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: jreleaser-release-output
           retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,16 @@ jobs:
       # checkout will clobber downloaded artifacts; we have to download them again
       - name: Download all build artifacts
         uses: actions/download-artifact@v4.1.0
+        with:
+          path: /tmp/artifacts
+
+      - name: Move build artifacts to correct folder
+        run: |
+          targets=("ubuntu-latest" "macOS-latest" "macOS-arm64-latest" "windows-latest")
+          
+          mkdir -p target/distributions
+          
+          find /tmp/artifacts/ -name "mcs*" -exec mv -v {} target/distributions/ \;
 
       - name: Set up Java
         uses: actions/setup-java@v3.13.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4.0.0
         with:
-          name: artifacts
+          name: artifacts-${{ matrix.os }}
           path: |
             target/distributions/*.zip
             target/distributions/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4.1.0
 
       - name: Read HEAD ref
         id: head
@@ -171,7 +171,7 @@ jobs:
     steps:
       # must read HEAD before checkout
       - name: Download all build artifacts
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4.1.0
 
       - name: Read HEAD ref
         id: head
@@ -202,7 +202,7 @@ jobs:
 
       # checkout will clobber downloaded artifacts; we have to download them again
       - name: Download all build artifacts
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4.1.0
 
       - name: Set up Java
         uses: actions/setup-java@v3.13.0


### PR DESCRIPTION
This replaces #297 and #298 - each of them can't be merged individually, and they require additional work in the pipeline.