### PR TITLE
chore(build): Download musl toolchain from alternative location

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           TMP_DIR=$(mktemp -d)
           pushd $TMP_DIR
-          curl -LOJ http://more.musl.cc/10/x86_64-linux-musl/x86_64-linux-musl-native.tgz
+          curl -LOJ https://more.musl.cc/10/x86_64-linux-musl/x86_64-linux-musl-native.tgz
           tar -xvf x86_64-linux-musl-native.tgz
           
           curl -LOJ https://zlib.net/fossils/zlib-1.3.tar.gz

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -63,10 +63,13 @@ jobs:
           mkdir -p ~/.musl-toolchain
           pushd ~/.musl-toolchain
           if [ ! -f x86_64-linux-musl-native.tgz ]; then
+            curl -u ${MUSL_TOOLCHAIN_USER}:${MUSL_TOOLCHAIN_PASS} -kLOJ ${MUSL_TOOLCHAIN_LOCATION}/10/x86_64-linux-musl/x86_64-linux-musl-native.tgz
+          fi
+          popd
+          
           TMP_DIR=$(mktemp -d)
           pushd $TMP_DIR
-          curl -LOJ https://github.com/mthmulders/mcs/releases/download/untagged-f7e4bad961bb6eb07796/x86_64-linux-musl-native.tgz
-          tar -xvf x86_64-linux-musl-native.tgz
+          tar -xvf ~/.musl-toolchain/x86_64-linux-musl-native.tgz
           
           curl -LOJ https://zlib.net/fossils/zlib-1.3.tar.gz
           tar -xzf zlib-1.3.tar.gz
@@ -81,6 +84,10 @@ jobs:
           
           echo "TOOLCHAIN_DIR=$TOOLCHAIN_DIR" >> $GITHUB_OUTPUT
         if: matrix.os == 'ubuntu-latest'
+        env:
+          MUSL_TOOLCHAIN_LOCATION: ${{ secrets.MUSL_TOOLCHAIN_LOCATION }}
+          MUSL_TOOLCHAIN_USER: ${{ secrets.MUSL_TOOLCHAIN_USER }}
+          MUSL_TOOLCHAIN_PASS: ${{ secrets.MUSL_TOOLCHAIN_PASS }}
 
       - name: Cache Maven packages
         id: restore-maven-package-cache

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -49,9 +49,20 @@ jobs:
           distribution: 'graalvm'
           java-version: 21
 
+      - name: Cache musl toolchain
+        id: musl-toolchain-cache
+        uses: actions/cache/restore@v4.2.3
+        if: matrix.os == 'ubuntu-latest'
+        with:
+          path: ~/.musl-toolchain
+          key: mcs-musl-toolchain
+
       - name: Get musl toolchain and compile libz against it
         id: prepare-musl
         run: |
+          mkdir -p ~/.musl-toolchain
+          pushd ~/.musl-toolchain
+          if [ ! -f x86_64-linux-musl-native.tgz ]; then
           TMP_DIR=$(mktemp -d)
           pushd $TMP_DIR
           curl -LOJ https://github.com/mthmulders/mcs/releases/download/untagged-f7e4bad961bb6eb07796/x86_64-linux-musl-native.tgz

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -55,7 +55,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         with:
           path: ~/.musl-toolchain
-          key: mcs-musl-toolchain
+          key: mcs-musl-toolchain-10
 
       - name: Get musl toolchain and compile libz against it
         id: prepare-musl
@@ -88,6 +88,12 @@ jobs:
           MUSL_TOOLCHAIN_LOCATION: ${{ secrets.MUSL_TOOLCHAIN_LOCATION }}
           MUSL_TOOLCHAIN_USER: ${{ secrets.MUSL_TOOLCHAIN_USER }}
           MUSL_TOOLCHAIN_PASS: ${{ secrets.MUSL_TOOLCHAIN_PASS }}
+
+      - name: Save musl toolchain
+        uses: actions/cache/save@v4.2.3
+        with:
+          path: ~/.musl-toolchain
+          key: mcs-musl-toolchain-10
 
       - name: Cache Maven packages
         id: restore-maven-package-cache

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           TMP_DIR=$(mktemp -d)
           pushd $TMP_DIR
-          curl -LOJ https://more.musl.cc/10/x86_64-linux-musl/x86_64-linux-musl-native.tgz
+          curl -LOJ https://github.com/mthmulders/mcs/releases/download/untagged-f7e4bad961bb6eb07796/x86_64-linux-musl-native.tgz
           tar -xvf x86_64-linux-musl-native.tgz
           
           curl -LOJ https://zlib.net/fossils/zlib-1.3.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         with:
           path: ~/.musl-toolchain
-          key: mcs-musl-toolchain
+          key: mcs-musl-toolchain-10
 
       - name: Get musl toolchain and compile libz against it
         id: prepare-musl
@@ -147,6 +147,12 @@ jobs:
           MUSL_TOOLCHAIN_LOCATION: ${{ secrets.MUSL_TOOLCHAIN_LOCATION }}
           MUSL_TOOLCHAIN_USER: ${{ secrets.MUSL_TOOLCHAIN_USER }}
           MUSL_TOOLCHAIN_PASS: ${{ secrets.MUSL_TOOLCHAIN_PASS }}
+
+      - name: Save musl toolchain
+        uses: actions/cache/save@v4.2.3
+        with:
+          path: ~/.musl-toolchain
+          key: mcs-musl-toolchain-10
 
       - name: Cache Maven packages
         uses: actions/cache@v4.2.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
         run: |
           TMP_DIR=$(mktemp -d)
           pushd $TMP_DIR
-          curl -LOJ http://more.musl.cc/10/x86_64-linux-musl/x86_64-linux-musl-native.tgz
+          curl -LOJ https://more.musl.cc/10/x86_64-linux-musl/x86_64-linux-musl-native.tgz
           tar -xvf x86_64-linux-musl-native.tgz
           
           curl -LOJ https://zlib.net/fossils/zlib-1.3.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
         run: |
           TMP_DIR=$(mktemp -d)
           pushd $TMP_DIR
-          curl -LOJ https://more.musl.cc/10/x86_64-linux-musl/x86_64-linux-musl-native.tgz
+          curl -LOJ https://github.com/mthmulders/mcs/releases/download/untagged-f7e4bad961bb6eb07796/x86_64-linux-musl-native.tgz
           tar -xvf x86_64-linux-musl-native.tgz
           
           curl -LOJ https://zlib.net/fossils/zlib-1.3.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,13 +108,27 @@ jobs:
           distribution: 'graalvm'
           java-version: 21
 
+      - name: Cache musl toolchain
+        id: musl-toolchain-cache
+        uses: actions/cache/restore@v4.2.3
+        if: matrix.os == 'ubuntu-latest'
+        with:
+          path: ~/.musl-toolchain
+          key: mcs-musl-toolchain
+
       - name: Get musl toolchain and compile libz against it
         id: prepare-musl
         run: |
+          mkdir -p ~/.musl-toolchain
+          pushd ~/.musl-toolchain
+          if [ ! -f x86_64-linux-musl-native.tgz ]; then
+            curl -u ${MUSL_TOOLCHAIN_USER}:${MUSL_TOOLCHAIN_PASS} -kLOJ ${MUSL_TOOLCHAIN_LOCATION}/10/x86_64-linux-musl/x86_64-linux-musl-native.tgz
+          fi
+          popd
+          
           TMP_DIR=$(mktemp -d)
           pushd $TMP_DIR
-          curl -LOJ https://github.com/mthmulders/mcs/releases/download/untagged-f7e4bad961bb6eb07796/x86_64-linux-musl-native.tgz
-          tar -xvf x86_64-linux-musl-native.tgz
+          tar -xvf ~/.musl-toolchain/x86_64-linux-musl-native.tgz
           
           curl -LOJ https://zlib.net/fossils/zlib-1.3.tar.gz
           tar -xzf zlib-1.3.tar.gz
@@ -129,6 +143,10 @@ jobs:
           
           echo "TOOLCHAIN_DIR=$TOOLCHAIN_DIR" >> $GITHUB_OUTPUT
         if: matrix.os == 'ubuntu-latest'
+        env:
+          MUSL_TOOLCHAIN_LOCATION: ${{ secrets.MUSL_TOOLCHAIN_LOCATION }}
+          MUSL_TOOLCHAIN_USER: ${{ secrets.MUSL_TOOLCHAIN_USER }}
+          MUSL_TOOLCHAIN_PASS: ${{ secrets.MUSL_TOOLCHAIN_PASS }}
 
       - name: Cache Maven packages
         uses: actions/cache@v4.2.3


### PR DESCRIPTION
Downloading over https seemed like an easy fix for #542, but given the root cause, this wasn't the solution.
Now hosting a privately hosted copy of the musl toolchain and caching it.