### PR TITLE
chore(build): Stabilise randomly failing native builds

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -56,15 +56,23 @@ jobs:
           path: ~/.musl-toolchain
           key: mcs-musl-toolchain-11
 
+      - name: Retrieve zlib from cache
+        id: zlib-toolchain-cache
+        uses: actions/cache/restore@v5.0.5
+        if: ${{ contains(matrix.os, 'ubuntu') }}
+        with:
+          path: ~/.zlib
+          key: mcs-zlib-1.3.2
+
       - name: Get musl toolchain and compile libz against it
         shell: bash
         id: prepare-musl
         run: |
-          echo "Downloading musl toolchain and compiling zlib against it..."
           mkdir -p ~/.musl-toolchain
           pushd ~/.musl-toolchain
           
           if [ ! -f x86_64-linux-musl-native.tgz ]; then
+            echo "Downloading and compiling musl libc toolchain 11..."
             curl \
                 --silent \
                 --insecure \
@@ -77,20 +85,25 @@ jobs:
           fi
           popd
           
-          TMP_DIR=$(mktemp -d)
-          pushd $TMP_DIR
-          tar -xvf ~/.musl-toolchain/x86_64-linux-musl-native.tgz
+          mkdir -p ~/.zlib
+          pushd ~/.zlib
+          if [ ! -f zlib-1.3.2.tar.gz ]; then
+              echo "Downloading and compiling zlib 1.3.2..."
+              curl \
+                --show-error \
+                --location \
+                --remote-name \
+                --remote-header-name \
+                --url "https://zlib.net/zlib-1.3.2.tar.gz"
+          fi
+          popd
           
-          echo "Downloading and compiling zlib 1.3.2..."
-          curl \
-            --show-error \
-            --location \
-            --remote-name \
-            --remote-header-name \
-            --url "https://zlib.net/zlib-1.3.2.tar.gz"
           tar -xzf zlib-1.3.2.tar.gz
           cd zlib-1.3.2
           
+          TMP_DIR=$(mktemp -d)
+          pushd $TMP_DIR
+          tar -xvf ~/.musl-toolchain/x86_64-linux-musl-native.tgz
           TOOLCHAIN_DIR=$TMP_DIR/x86_64-linux-musl-native
           CC=$TOOLCHAIN_DIR/bin/gcc
           
@@ -113,6 +126,13 @@ jobs:
         with:
           path: ~/.musl-toolchain
           key: mcs-musl-toolchain-11
+
+      - name: Save zlib toolchain to cache
+        uses: actions/cache/save@v5.0.5
+        if: ${{ contains(matrix.os, 'ubuntu') }}
+        with:
+          path: ~/.zlib
+          key: mcs-zlib-1.3.2
 
       - name: Cache Maven packages
         id: restore-maven-package-cache

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -81,9 +81,8 @@ jobs:
           pushd $TMP_DIR
           tar -xvf ~/.musl-toolchain/x86_64-linux-musl-native.tgz
           
-          echo "Downloading and compiling zlib 1.3..."
+          echo "Downloading and compiling zlib 1.3.2..."
           curl \
-            --silent \
             --show-error \
             --location \
             --remote-name \

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -98,9 +98,6 @@ jobs:
           fi
           popd
           
-          tar -xzf zlib-1.3.2.tar.gz
-          cd zlib-1.3.2
-          
           TMP_DIR=$(mktemp -d)
           pushd $TMP_DIR
           tar -xvf ~/.musl-toolchain/x86_64-linux-musl-native.tgz
@@ -108,6 +105,8 @@ jobs:
           CC=$TOOLCHAIN_DIR/bin/gcc
           
           echo "Configuring and installing zlib..."
+          tar -xzf ~/.zlib/zlib-1.3.2.tar.gz
+          cd zlib-1.3.2
           ./configure --prefix=$TOOLCHAIN_DIR --static
           make
           make install

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -99,12 +99,12 @@ jobs:
           
           TMP_DIR=$(mktemp -d)
           pushd $TMP_DIR
-          tar -xvf ~/.musl-toolchain/x86_64-linux-musl-native.tgz
+          tar -xf ~/.musl-toolchain/x86_64-linux-musl-native.tgz
           TOOLCHAIN_DIR=$TMP_DIR/x86_64-linux-musl-native
           CC=$TOOLCHAIN_DIR/bin/gcc
           
           echo "Configuring and installing zlib..."
-          tar -xzf ~/.zlib/zlib-1.3.2.tar.gz
+          tar -xf ~/.zlib/zlib-1.3.2.tar.gz
           cd zlib-1.3.2
           ./configure --prefix=$TOOLCHAIN_DIR --static
           make

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -119,8 +119,7 @@ jobs:
           make
           make install
           
-          echo ""
-          echo "Prepared musl toolchain at $TOOLCHAIN_DIR"
+          echo "\nPrepared musl toolchain at $TOOLCHAIN_DIR"
           echo "TOOLCHAIN_DIR=$TOOLCHAIN_DIR" >> $GITHUB_OUTPUT
 
       - name: Save musl toolchain to cache
@@ -151,7 +150,7 @@ jobs:
           export PATH
           mvn -B -Pnative -Pdist verify
         env:
-          TOOLCHAIN_DIR: ${{ steps.prepare-musl.outputs.TOOLCHAIN_DIR }}
+          TOOLCHAIN_DIR: ${{ steps.build-libz.outputs.TOOLCHAIN_DIR }}
         if: ${{ contains(matrix.os, 'ubuntu') }}
 
       - name: Build static native image for Windows / macOS

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -74,7 +74,6 @@ jobs:
           if [ ! -f x86_64-linux-musl-native.tgz ]; then
             echo "Downloading and compiling musl libc toolchain 11..."
             curl \
-                --silent \
                 --insecure \
                 --show-error \
                 --user "${MUSL_TOOLCHAIN_USER}:${MUSL_TOOLCHAIN_PASS}" \

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -56,6 +56,28 @@ jobs:
           path: ~/.musl-toolchain
           key: mcs-musl-toolchain-11
 
+      - name: Get musl toolchain
+        if: ${{ steps.musl-toolchain-cache.outputs.cache-hit != 'true' && contains(matrix.os, 'ubuntu') }}
+        shell: bash
+        id: get-musl-toolchain
+        run: |
+          mkdir -p ~/.musl-toolchain
+          pushd ~/.musl-toolchain
+          
+          echo "Downloading and compiling musl libc toolchain 11..."
+          curl \
+              --insecure \
+              --show-error \
+              --user "${MUSL_TOOLCHAIN_USER}:${MUSL_TOOLCHAIN_PASS}" \
+              --location \
+              --remote-name \
+              --remote-header-name \
+              --url "${MUSL_TOOLCHAIN_LOCATION}/11/x86_64-linux-musl/x86_64-linux-musl-native.tgz"
+        env:
+          MUSL_TOOLCHAIN_LOCATION: ${{ secrets.MUSL_TOOLCHAIN_LOCATION }}
+          MUSL_TOOLCHAIN_USER: ${{ secrets.MUSL_TOOLCHAIN_USER }}
+          MUSL_TOOLCHAIN_PASS: ${{ secrets.MUSL_TOOLCHAIN_PASS }}
+
       - name: Retrieve zlib from cache
         id: zlib-toolchain-cache
         uses: actions/cache/restore@v5.0.5
@@ -64,39 +86,26 @@ jobs:
           path: ~/.zlib
           key: mcs-zlib-1.3.2
 
-      - name: Get musl toolchain and compile libz against it
+      - name: Get libz
         shell: bash
-        id: prepare-musl
+        id: get-libz
+        if: ${{ steps.zlib-toolchain-cache.outputs.cache-hit != 'true' && contains(matrix.os, 'ubuntu') }}
         run: |
-          mkdir -p ~/.musl-toolchain
-          pushd ~/.musl-toolchain
-          
-          if [ ! -f x86_64-linux-musl-native.tgz ]; then
-            echo "Downloading and compiling musl libc toolchain 11..."
-            curl \
-                --insecure \
-                --show-error \
-                --user "${MUSL_TOOLCHAIN_USER}:${MUSL_TOOLCHAIN_PASS}" \
-                --location \
-                --remote-name \
-                --remote-header-name \
-                --url "${MUSL_TOOLCHAIN_LOCATION}/11/x86_64-linux-musl/x86_64-linux-musl-native.tgz"
-          fi
-          popd
-          
           mkdir -p ~/.zlib
           pushd ~/.zlib
-          if [ ! -f zlib-1.3.2.tar.gz ]; then
-              echo "Downloading and compiling zlib 1.3.2..."
-              curl \
-                --show-error \
-                --location \
-                --remote-name \
-                --remote-header-name \
-                --url "https://zlib.net/zlib-1.3.2.tar.gz"
-          fi
-          popd
-          
+          echo "Downloading and compiling zlib 1.3.2..."
+          curl \
+            --show-error \
+            --location \
+            --remote-name \
+            --remote-header-name \
+            --url "https://zlib.net/zlib-1.3.2.tar.gz"
+
+      - name: Build libz with musl toolchain
+        shell: bash
+        id: build-libz
+        if: ${{ contains(matrix.os, 'ubuntu') }}
+        run: |
           TMP_DIR=$(mktemp -d)
           pushd $TMP_DIR
           tar -xf ~/.musl-toolchain/x86_64-linux-musl-native.tgz
@@ -112,11 +121,6 @@ jobs:
           
           echo "Prepared musl toolchain at $TOOLCHAIN_DIR"
           echo "TOOLCHAIN_DIR=$TOOLCHAIN_DIR" >> $GITHUB_OUTPUT
-        if: ${{ contains(matrix.os, 'ubuntu') }}
-        env:
-          MUSL_TOOLCHAIN_LOCATION: ${{ secrets.MUSL_TOOLCHAIN_LOCATION }}
-          MUSL_TOOLCHAIN_USER: ${{ secrets.MUSL_TOOLCHAIN_USER }}
-          MUSL_TOOLCHAIN_PASS: ${{ secrets.MUSL_TOOLCHAIN_PASS }}
 
       - name: Save musl toolchain to cache
         uses: actions/cache/save@v5.0.5

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -106,7 +106,7 @@ jobs:
         id: build-libz
         if: ${{ contains(matrix.os, 'ubuntu') }}
         run: |
-          TMP_DIR=$(mktemp -d)
+          TMP_DIR=$(mktemp -d -p `pwd`)
           pushd $TMP_DIR
           tar -xf ~/.musl-toolchain/x86_64-linux-musl-native.tgz
           TOOLCHAIN_DIR=$TMP_DIR/x86_64-linux-musl-native
@@ -119,6 +119,7 @@ jobs:
           make
           make install
           
+          echo ""
           echo "Prepared musl toolchain at $TOOLCHAIN_DIR"
           echo "TOOLCHAIN_DIR=$TOOLCHAIN_DIR" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Every now and then, the download of libz would fail without clear information. This MR caches a downloaded libz source archive so the build becomes faster (theoretically) and more resilient against such download failures.