### PR TITLE
feat: add --copy flag to copy single-result coordinates to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ This tool supports the following modes of searching:
 ## Flags
 
 * All modes recognise the `-l <number>` switch, which lets you specify how many results you want to see _at most_.
-* In **Wildcard sarch** and **Coordinate search**, you can pass along the `-s` (or `--show-vulnerabilities`) flag.
+* In **Wildcard search** and **Coordinate search**, you can pass the `-c` (or `--copy`) flag.
+  When the search returns exactly one result, MCS will copy the coordinates to your clipboard.
+  On 🍎, this uses `pbcopy`. On 🪟, it uses `clip`. On 🐧, it tries `wl-copy`, `xclip` and `xsel`.
+* In **Wildcard search** and **Coordinate search**, you can also pass the `-s` (or `--show-vulnerabilities`) flag.
   It will cause MCS to show a summary of reported security vulnerabilities against each result.
   If there is only one search result, it will display the CVE numbers reported against that result.
   **Note** that this feature will probably soon hit the API limits for the Sonatype OSS Index.

--- a/src/main/java/it/mulders/mcs/cli/ClassSearchCommand.java
+++ b/src/main/java/it/mulders/mcs/cli/ClassSearchCommand.java
@@ -31,6 +31,11 @@ public class ClassSearchCommand implements Callable<Integer> {
             paramLabel = "<count>")
     private Integer limit;
 
+    @CommandLine.Option(
+            names = {"-c", "--copy"},
+            description = "Copy the coordinates to the clipboard when the search returns exactly one result")
+    private boolean copy;
+
     private final SearchCommandHandler searchCommandHandler;
 
     @Inject
@@ -39,11 +44,17 @@ public class ClassSearchCommand implements Callable<Integer> {
     }
 
     // Visible for testing
-    ClassSearchCommand(final SearchCommandHandler searchCommandHandler, String query, Integer limit, boolean fullName) {
+    ClassSearchCommand(
+            final SearchCommandHandler searchCommandHandler,
+            String query,
+            Integer limit,
+            boolean fullName,
+            boolean copy) {
         this(searchCommandHandler);
         this.fullName = fullName;
         this.limit = limit;
         this.query = query;
+        this.copy = copy;
     }
 
     @Override
@@ -53,7 +64,7 @@ public class ClassSearchCommand implements Callable<Integer> {
                 .isFullyQualified(this.fullName)
                 .withLimit(limit)
                 .build();
-        searchCommandHandler.search(searchQuery, "maven", false);
+        searchCommandHandler.search(searchQuery, "maven", false, copy);
         return 0;
     }
 }

--- a/src/main/java/it/mulders/mcs/cli/SearchCommand.java
+++ b/src/main/java/it/mulders/mcs/cli/SearchCommand.java
@@ -42,6 +42,11 @@ public class SearchCommand implements Callable<Integer> {
             paramLabel = "<vulnerabilities>")
     private boolean showVulnerabilities;
 
+    @CommandLine.Option(
+            names = {"-c", "--copy"},
+            description = "Copy the coordinates to the clipboard when the search returns exactly one result")
+    private boolean copy;
+
     private final SearchCommandHandler searchCommandHandler;
 
     @Inject
@@ -55,12 +60,14 @@ public class SearchCommand implements Callable<Integer> {
             String[] query,
             Integer limit,
             String responseFormat,
-            boolean showVulnerabilities) {
+            boolean showVulnerabilities,
+            boolean copy) {
         this(searchCommandHandler);
         this.limit = limit;
         this.query = query;
         this.responseFormat = responseFormat;
         this.showVulnerabilities = showVulnerabilities;
+        this.copy = copy;
     }
 
     @Override
@@ -70,7 +77,7 @@ public class SearchCommand implements Callable<Integer> {
         var searchQuery =
                 SearchQuery.search(combinedQuery).withLimit(this.limit).build();
 
-        searchCommandHandler.search(searchQuery, responseFormat, showVulnerabilities);
+        searchCommandHandler.search(searchQuery, responseFormat, showVulnerabilities, copy);
         return 0;
     }
 }

--- a/src/main/java/it/mulders/mcs/clipboard/Clipboard.java
+++ b/src/main/java/it/mulders/mcs/clipboard/Clipboard.java
@@ -1,0 +1,5 @@
+package it.mulders.mcs.clipboard;
+
+public interface Clipboard {
+    boolean copy(final String text);
+}

--- a/src/main/java/it/mulders/mcs/clipboard/LinuxClipboard.java
+++ b/src/main/java/it/mulders/mcs/clipboard/LinuxClipboard.java
@@ -1,0 +1,21 @@
+package it.mulders.mcs.clipboard;
+
+import static it.mulders.mcs.clipboard.Shell.run;
+import static it.mulders.mcs.clipboard.Shell.which;
+
+import java.util.List;
+
+public final class LinuxClipboard implements Clipboard {
+    @Override
+    public boolean copy(final String text) {
+        if (which("wl-copy")) {
+            return run("wl-copy", text);
+        } else if (which("xclip")) {
+            return run(List.of("xclip", "-selection", "clipboard"), text);
+        } else if (which("xsel")) {
+            return run(List.of("xsel", "--clipboard"), text);
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/main/java/it/mulders/mcs/clipboard/LinuxClipboard.java
+++ b/src/main/java/it/mulders/mcs/clipboard/LinuxClipboard.java
@@ -15,6 +15,7 @@ public final class LinuxClipboard implements Clipboard {
         } else if (which("xsel")) {
             return run(List.of("xsel", "--clipboard"), text);
         } else {
+            System.err.println("Failed to find supported clipboard command. Tried wl-copy, xclip, and xsel");
             return false;
         }
     }

--- a/src/main/java/it/mulders/mcs/clipboard/LinuxClipboard.java
+++ b/src/main/java/it/mulders/mcs/clipboard/LinuxClipboard.java
@@ -1,19 +1,27 @@
 package it.mulders.mcs.clipboard;
 
-import static it.mulders.mcs.clipboard.Shell.run;
-import static it.mulders.mcs.clipboard.Shell.which;
-
 import java.util.List;
 
 public final class LinuxClipboard implements Clipboard {
+    private final Shell shell;
+
+    public LinuxClipboard() {
+        this(new Shell());
+    }
+
+    // for testing
+    LinuxClipboard(final Shell shell) {
+        this.shell = shell;
+    }
+
     @Override
     public boolean copy(final String text) {
-        if (which("wl-copy")) {
-            return run("wl-copy", text);
-        } else if (which("xclip")) {
-            return run(List.of("xclip", "-selection", "clipboard"), text);
-        } else if (which("xsel")) {
-            return run(List.of("xsel", "--clipboard"), text);
+        if (shell.which("wl-copy")) {
+            return shell.run("wl-copy", text);
+        } else if (shell.which("xclip")) {
+            return shell.run(List.of("xclip", "-selection", "clipboard"), text);
+        } else if (shell.which("xsel")) {
+            return shell.run(List.of("xsel", "--clipboard"), text);
         } else {
             System.err.println("Failed to find supported clipboard command. Tried wl-copy, xclip, and xsel");
             return false;

--- a/src/main/java/it/mulders/mcs/clipboard/MacClipboard.java
+++ b/src/main/java/it/mulders/mcs/clipboard/MacClipboard.java
@@ -1,0 +1,8 @@
+package it.mulders.mcs.clipboard;
+
+public final class MacClipboard implements Clipboard {
+    @Override
+    public boolean copy(final String text) {
+        return Shell.run("pbcopy", text);
+    }
+}

--- a/src/main/java/it/mulders/mcs/clipboard/MacClipboard.java
+++ b/src/main/java/it/mulders/mcs/clipboard/MacClipboard.java
@@ -1,8 +1,19 @@
 package it.mulders.mcs.clipboard;
 
 public final class MacClipboard implements Clipboard {
+    private final Shell shell;
+
+    public MacClipboard() {
+        this(new Shell());
+    }
+
+    // for testing
+    MacClipboard(final Shell shell) {
+        this.shell = shell;
+    }
+
     @Override
     public boolean copy(final String text) {
-        return Shell.run("pbcopy", text);
+        return shell.run("pbcopy", text);
     }
 }

--- a/src/main/java/it/mulders/mcs/clipboard/NoOpClipboard.java
+++ b/src/main/java/it/mulders/mcs/clipboard/NoOpClipboard.java
@@ -1,0 +1,8 @@
+package it.mulders.mcs.clipboard;
+
+public final class NoOpClipboard implements Clipboard {
+    @Override
+    public boolean copy(final String text) {
+        return false;
+    }
+}

--- a/src/main/java/it/mulders/mcs/clipboard/Shell.java
+++ b/src/main/java/it/mulders/mcs/clipboard/Shell.java
@@ -6,9 +6,9 @@ import java.time.Duration;
 import java.util.List;
 
 final class Shell {
-    private Shell() {}
+    Shell() {}
 
-    static boolean which(final String command) {
+    boolean which(final String command) {
         try {
             return new ProcessBuilder("which", command).start().waitFor() == 0;
         } catch (InterruptedException e) {
@@ -19,11 +19,11 @@ final class Shell {
         }
     }
 
-    static boolean run(final String command, final String stdin) {
+    boolean run(final String command, final String stdin) {
         return run(List.of(command), stdin);
     }
 
-    static boolean run(final List<String> command, final String stdin) {
+    boolean run(final List<String> command, final String stdin) {
         try {
             var process = new ProcessBuilder(command).start();
             try (var out = process.getOutputStream()) {

--- a/src/main/java/it/mulders/mcs/clipboard/Shell.java
+++ b/src/main/java/it/mulders/mcs/clipboard/Shell.java
@@ -1,0 +1,45 @@
+package it.mulders.mcs.clipboard;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+
+final class Shell {
+    private Shell() {}
+
+    static boolean which(final String command) {
+        try {
+            return new ProcessBuilder("which", command).start().waitFor() == 0;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    static boolean run(final String command, final String stdin) {
+        return run(List.of(command), stdin);
+    }
+
+    static boolean run(final List<String> command, final String stdin) {
+        try {
+            var process = new ProcessBuilder(command).start();
+            try (var out = process.getOutputStream()) {
+                out.write(stdin.getBytes(StandardCharsets.UTF_8));
+            }
+
+            if (!process.waitFor(Duration.ofSeconds(3))) {
+                process.destroyForcibly();
+                return false;
+            }
+            return process.exitValue() == 0;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/it/mulders/mcs/clipboard/WindowsClipboard.java
+++ b/src/main/java/it/mulders/mcs/clipboard/WindowsClipboard.java
@@ -1,8 +1,19 @@
 package it.mulders.mcs.clipboard;
 
 public final class WindowsClipboard implements Clipboard {
+    private final Shell shell;
+
+    public WindowsClipboard() {
+        this(new Shell());
+    }
+
+    // for testing
+    WindowsClipboard(final Shell shell) {
+        this.shell = shell;
+    }
+
     @Override
     public boolean copy(final String text) {
-        return Shell.run("clip", text);
+        return shell.run("clip", text);
     }
 }

--- a/src/main/java/it/mulders/mcs/clipboard/WindowsClipboard.java
+++ b/src/main/java/it/mulders/mcs/clipboard/WindowsClipboard.java
@@ -1,0 +1,8 @@
+package it.mulders.mcs.clipboard;
+
+public final class WindowsClipboard implements Clipboard {
+    @Override
+    public boolean copy(final String text) {
+        return Shell.run("clip", text);
+    }
+}

--- a/src/main/java/it/mulders/mcs/dagger/Application.java
+++ b/src/main/java/it/mulders/mcs/dagger/Application.java
@@ -5,7 +5,7 @@ import it.mulders.mcs.cli.SearchCommand;
 import it.mulders.mcs.cli.SystemPropertyLoader;
 import picocli.CommandLine;
 
-@Component(modules = {CommandLineModule.class, OutputModule.class, SearchModule.class})
+@Component(modules = {ClipboardModule.class, CommandLineModule.class, OutputModule.class, SearchModule.class})
 public interface Application {
     CommandLine commandLine();
 

--- a/src/main/java/it/mulders/mcs/dagger/ClipboardModule.java
+++ b/src/main/java/it/mulders/mcs/dagger/ClipboardModule.java
@@ -1,0 +1,27 @@
+package it.mulders.mcs.dagger;
+
+import dagger.Module;
+import dagger.Provides;
+import it.mulders.mcs.clipboard.Clipboard;
+import it.mulders.mcs.clipboard.LinuxClipboard;
+import it.mulders.mcs.clipboard.MacClipboard;
+import it.mulders.mcs.clipboard.NoOpClipboard;
+import it.mulders.mcs.clipboard.WindowsClipboard;
+import java.util.Locale;
+
+@Module
+public interface ClipboardModule {
+    @Provides
+    static Clipboard provideClipboard() {
+        var os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+        if (os.contains("mac")) {
+            return new MacClipboard();
+        } else if (os.contains("win")) {
+            return new WindowsClipboard();
+        } else if (os.contains("nux") || os.contains("bsd")) {
+            return new LinuxClipboard();
+        } else {
+            return new NoOpClipboard();
+        }
+    }
+}

--- a/src/main/java/it/mulders/mcs/dagger/ClipboardModule.java
+++ b/src/main/java/it/mulders/mcs/dagger/ClipboardModule.java
@@ -21,6 +21,7 @@ public interface ClipboardModule {
         } else if (os.contains("nux") || os.contains("bsd")) {
             return new LinuxClipboard();
         } else {
+            System.err.printf("Unsupported operating system: %s%n", os);
             return new NoOpClipboard();
         }
     }

--- a/src/main/java/it/mulders/mcs/printer/ClipboardOutputPrinter.java
+++ b/src/main/java/it/mulders/mcs/printer/ClipboardOutputPrinter.java
@@ -1,0 +1,36 @@
+package it.mulders.mcs.printer;
+
+import it.mulders.mcs.clipboard.Clipboard;
+import it.mulders.mcs.search.artifact.SearchQuery;
+import it.mulders.mcs.search.artifact.SearchResponse;
+import java.io.PrintStream;
+
+/**
+ * Decorates a {@link CoordinatePrinter} with logic to copy the coordinate snippet to the clipboard after it has been printed.
+ */
+public final class ClipboardOutputPrinter implements OutputPrinter {
+    private final OutputPrinter delegate;
+    private final Clipboard clipboard;
+    private final boolean copy;
+
+    public ClipboardOutputPrinter(final OutputPrinter delegate, final Clipboard clipboard, final boolean copy) {
+        this.delegate = delegate;
+        this.clipboard = clipboard;
+        this.copy = copy;
+    }
+
+    @Override
+    public void print(final SearchQuery query, final SearchResponse.Response response, final PrintStream stream) {
+        delegate.print(query, response, stream);
+
+        if (copy) {
+            if (delegate instanceof CoordinatePrinter cp) {
+                var coordinates = cp.provideCoordinates(response.docs()[0]);
+                stream.println(
+                        clipboard.copy(coordinates) ? "Snippet copied to clipboard." : "Could not copy to clipboard.");
+            }
+        } else {
+            stream.println("Pass -c or --copy to copy this snippet to your clipboard.");
+        }
+    }
+}

--- a/src/main/java/it/mulders/mcs/printer/CoordinatePrinter.java
+++ b/src/main/java/it/mulders/mcs/printer/CoordinatePrinter.java
@@ -23,6 +23,10 @@ public sealed interface CoordinatePrinter extends OutputPrinter
 
     String provideCoordinates(final String group, final String artifact, final String version, final String packaging);
 
+    default String provideCoordinates(final SearchResponse.Response.Doc doc) {
+        return provideCoordinates(doc.g(), doc.a(), first(doc.v(), doc.latestVersion()), doc.p());
+    }
+
     @Override
     default void print(final SearchQuery query, final SearchResponse.Response response, final PrintStream stream) {
         if (response.numFound() != 1) {
@@ -31,7 +35,7 @@ public sealed interface CoordinatePrinter extends OutputPrinter
 
         var doc = response.docs()[0];
         stream.println();
-        stream.println(provideCoordinates(doc.g(), doc.a(), first(doc.v(), doc.latestVersion()), doc.p()));
+        stream.println(provideCoordinates(doc));
         stream.println();
         printVulnerabilities(doc.componentReport(), stream);
     }

--- a/src/main/java/it/mulders/mcs/printer/GrapeOutput.java
+++ b/src/main/java/it/mulders/mcs/printer/GrapeOutput.java
@@ -9,6 +9,6 @@ public final class GrapeOutput implements CoordinatePrinter {
                 @Grapes(
                     @Grab(group='%s', module='%s', version='%s')
                 )
-                """.formatted(group, artifact, version);
+                """.stripTrailing().formatted(group, artifact, version);
     }
 }

--- a/src/main/java/it/mulders/mcs/printer/IvyXmlOutput.java
+++ b/src/main/java/it/mulders/mcs/printer/IvyXmlOutput.java
@@ -7,6 +7,6 @@ public final class IvyXmlOutput implements CoordinatePrinter {
             final String group, final String artifact, final String version, String packaging) {
         return """
                 <dependency org="%s" name="%s" rev="%s"/>
-                """.formatted(group, artifact, version);
+                """.stripTrailing().formatted(group, artifact, version);
     }
 }

--- a/src/main/java/it/mulders/mcs/printer/PomXmlOutput.java
+++ b/src/main/java/it/mulders/mcs/printer/PomXmlOutput.java
@@ -12,6 +12,6 @@ public final class PomXmlOutput implements CoordinatePrinter {
                         <artifactId>%s</artifactId>
                         <version>%s</version>
                     </%4$s>
-                """.formatted(group, artifact, version, element);
+                """.stripTrailing().formatted(group, artifact, version, element);
     }
 }

--- a/src/main/java/it/mulders/mcs/printer/SbtOutput.java
+++ b/src/main/java/it/mulders/mcs/printer/SbtOutput.java
@@ -7,6 +7,6 @@ public final class SbtOutput implements CoordinatePrinter {
             final String group, final String artifact, final String version, String packaging) {
         return """
                 libraryDependencies += "%s" %% "%s" %% "%s"
-                """.formatted(group, artifact, version);
+                """.stripTrailing().formatted(group, artifact, version);
     }
 }

--- a/src/main/java/it/mulders/mcs/search/SearchCommandHandler.java
+++ b/src/main/java/it/mulders/mcs/search/SearchCommandHandler.java
@@ -2,8 +2,10 @@ package it.mulders.mcs.search;
 
 import static it.mulders.mcs.Constants.MAX_LIMIT;
 
+import it.mulders.mcs.clipboard.Clipboard;
 import it.mulders.mcs.common.McsRuntimeException;
 import it.mulders.mcs.common.Result;
+import it.mulders.mcs.printer.ClipboardOutputPrinter;
 import it.mulders.mcs.printer.DelegatingOutputPrinter;
 import it.mulders.mcs.printer.OutputFactory;
 import it.mulders.mcs.search.artifact.SearchClient;
@@ -15,21 +17,28 @@ import jakarta.inject.Inject;
 import java.util.stream.Stream;
 
 public class SearchCommandHandler {
+    private final Clipboard clipboard;
     private final OutputFactory outputFactory;
     private final SearchClient searchClient;
     private final ComponentReportClient reportClient;
 
     @Inject
     public SearchCommandHandler(
+            final Clipboard clipboard,
             final ComponentReportClient reportClient,
             final OutputFactory outputFactory,
             final SearchClient searchClient) {
+        this.clipboard = clipboard;
         this.outputFactory = outputFactory;
         this.reportClient = reportClient;
         this.searchClient = searchClient;
     }
 
-    public void search(final SearchQuery query, final String outputFormat, final boolean reportVulnerabilities) {
+    public void search(
+            final SearchQuery query,
+            final String outputFormat,
+            final boolean reportVulnerabilities,
+            final boolean copy) {
         performSearch(query)
                 .map(response -> performAdditionalSearch(query, response))
                 .ifPresentOrElse(
@@ -37,7 +46,7 @@ public class SearchCommandHandler {
                             if (reportVulnerabilities) {
                                 processResponse(query, response);
                             }
-                            printResponse(query, response, outputFormat, reportVulnerabilities);
+                            printResponse(query, response, outputFormat, reportVulnerabilities, copy);
                         },
                         failure -> {
                             throw new McsRuntimeException(failure);
@@ -98,8 +107,11 @@ public class SearchCommandHandler {
             final SearchQuery query,
             final SearchResponse.Response response,
             final String outputFormat,
-            final boolean showVulnerabilities) {
-        var printer = new DelegatingOutputPrinter(outputFactory.findOutputPrinter(outputFormat), showVulnerabilities);
+            final boolean showVulnerabilities,
+            final boolean copy) {
+        var outputPrinter = outputFactory.findOutputPrinter(outputFormat);
+        var coordinateOutput = new ClipboardOutputPrinter(outputPrinter, clipboard, copy);
+        var printer = new DelegatingOutputPrinter(coordinateOutput, showVulnerabilities);
         printer.print(query, response, System.out);
     }
 }

--- a/src/test/java/it/mulders/mcs/cli/ClassSearchCommandTest.java
+++ b/src/test/java/it/mulders/mcs/cli/ClassSearchCommandTest.java
@@ -20,20 +20,20 @@ class ClassSearchCommandTest implements WithAssertions {
     @Test
     void delegates_to_handler() {
         // Arrange
-        var command = new ClassSearchCommand(searchCommandHandler, "test", null, false);
+        var command = new ClassSearchCommand(searchCommandHandler, "test", null, false, false);
 
         // Act
         command.call();
 
         // Assert
         var query = SearchQuery.classSearch("test").build();
-        verifyHandlerInvocation("maven", false, query);
+        verifyHandlerInvocation("maven", false, false, query);
     }
 
     @Test
     void accepts_full_name_parameter() {
         // Arrange
-        var command = new ClassSearchCommand(searchCommandHandler, "test", null, true);
+        var command = new ClassSearchCommand(searchCommandHandler, "test", null, true, false);
 
         // Act
         command.call();
@@ -43,12 +43,26 @@ class ClassSearchCommandTest implements WithAssertions {
                 .isFullyQualified(true)
                 .withLimit(Constants.DEFAULT_MAX_SEARCH_RESULTS)
                 .build();
-        verifyHandlerInvocation("maven", false, query);
+        verifyHandlerInvocation("maven", false, false, query);
     }
 
-    private void verifyHandlerInvocation(String outputFormat, boolean reportVulnerabilities, SearchQuery query) {
+    @Test
+    void accepts_copy_parameter() {
+        // Arrange
+        var command = new ClassSearchCommand(searchCommandHandler, "test", null, false, true);
+
+        // Act
+        command.call();
+
+        // Assert
+        var query = SearchQuery.classSearch("test").build();
+        verifyHandlerInvocation("maven", false, true, query);
+    }
+
+    private void verifyHandlerInvocation(
+            String outputFormat, boolean reportVulnerabilities, boolean copy, SearchQuery query) {
         var captor = ArgumentCaptor.forClass(SearchQuery.class);
-        verify(searchCommandHandler).search(captor.capture(), eq(outputFormat), eq(reportVulnerabilities));
+        verify(searchCommandHandler).search(captor.capture(), eq(outputFormat), eq(reportVulnerabilities), eq(copy));
         assertThat(captor.getValue()).isEqualTo(query);
     }
 }

--- a/src/test/java/it/mulders/mcs/cli/SearchCommandTest.java
+++ b/src/test/java/it/mulders/mcs/cli/SearchCommandTest.java
@@ -19,71 +19,87 @@ class SearchCommandTest implements WithAssertions {
     @Test
     void delegates_to_handler() {
         // Arrange
-        var command = new SearchCommand(searchCommandHandler, new String[] {"test"}, null, "maven", false);
+        var command = new SearchCommand(searchCommandHandler, new String[] {"test"}, null, "maven", false, false);
 
         // Act
         command.call();
 
         // Assert
         var query = SearchQuery.search("test").build();
-        verifyHandlerInvocation("maven", false, query);
+        verifyHandlerInvocation("maven", false, false, query);
     }
 
     @Test
     void accepts_space_separated_terms() {
         // Arrange
-        var command = new SearchCommand(searchCommandHandler, new String[] {"jakarta", "rs"}, null, "maven", false);
+        var command =
+                new SearchCommand(searchCommandHandler, new String[] {"jakarta", "rs"}, null, "maven", false, false);
 
         // Act
         command.call();
 
         // Assert
         var query = SearchQuery.search("jakarta rs").build();
-        verifyHandlerInvocation("maven", false, query);
+        verifyHandlerInvocation("maven", false, false, query);
     }
 
     @Test
     void accepts_limit_results_parameter() {
         // Arrange
-        var command = new SearchCommand(searchCommandHandler, new String[] {"test"}, 3, "maven", false);
+        var command = new SearchCommand(searchCommandHandler, new String[] {"test"}, 3, "maven", false, false);
 
         // Act
         command.call();
 
         // Assert
         var query = SearchQuery.search("test").withLimit(3).build();
-        verifyHandlerInvocation("maven", false, query);
+        verifyHandlerInvocation("maven", false, false, query);
     }
 
     @Test
     void accepts_output_type_parameter() {
         // Arrange
-        var command = new SearchCommand(searchCommandHandler, new String[] {"test"}, null, "gradle-short", false);
+        var command =
+                new SearchCommand(searchCommandHandler, new String[] {"test"}, null, "gradle-short", false, false);
 
         // Act
         command.call();
 
         // Assert
         var query = SearchQuery.search("test").build();
-        verifyHandlerInvocation("gradle-short", false, query);
+        verifyHandlerInvocation("gradle-short", false, false, query);
     }
 
     @Test
     void accepts_show_vulnerabilities_parameter() {
         // Arrange
-        var command = new SearchCommand(searchCommandHandler, new String[] {"test"}, null, "maven", true);
+        var command = new SearchCommand(searchCommandHandler, new String[] {"test"}, null, "maven", true, false);
 
         // Act
         command.call();
 
         // Assert
         var query = SearchQuery.search("test").build();
-        verifyHandlerInvocation("maven", true, query);
+        verifyHandlerInvocation("maven", true, false, query);
     }
 
-    private void verifyHandlerInvocation(String outputFormat, boolean reportVulnerabilities, SearchQuery query) {
+    @Test
+    void accepts_copy_parameter() {
+        // Arrange
+        var command = new SearchCommand(searchCommandHandler, new String[] {"test"}, null, "maven", false, true);
+
+        // Act
+        command.call();
+
+        // Assert
+        var query = SearchQuery.search("test").build();
+        verifyHandlerInvocation("maven", false, true, query);
+    }
+
+    private void verifyHandlerInvocation(
+            String outputFormat, boolean reportVulnerabilities, boolean copy, SearchQuery query) {
         var captor = ArgumentCaptor.forClass(SearchQuery.class);
-        verify(searchCommandHandler).search(captor.capture(), eq(outputFormat), eq(reportVulnerabilities));
+        verify(searchCommandHandler).search(captor.capture(), eq(outputFormat), eq(reportVulnerabilities), eq(copy));
         assertThat(captor.getValue()).isEqualTo(query);
     }
 }

--- a/src/test/java/it/mulders/mcs/clipboard/ClipboardTest.java
+++ b/src/test/java/it/mulders/mcs/clipboard/ClipboardTest.java
@@ -1,0 +1,110 @@
+package it.mulders.mcs.clipboard;
+
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ClipboardTest implements WithAssertions {
+
+    private final Shell shell = mock(Shell.class);
+
+    @Test
+    void noop_clipboard_returns_false() {
+        assertThat(new NoOpClipboard().copy("test")).isFalse();
+    }
+
+    @Test
+    void mac_clipboard_uses_pbcopy() {
+        // Arrange
+        when(shell.run("pbcopy", "test")).thenReturn(true);
+
+        // Act
+        var result = new MacClipboard(shell).copy("test");
+
+        // Assert
+        assertThat(result).isTrue();
+        verify(shell).run("pbcopy", "test");
+    }
+
+    @Test
+    void windows_clipboard_uses_clip() {
+        // Arrange
+        when(shell.run("clip", "test")).thenReturn(true);
+
+        // Act
+        var result = new WindowsClipboard(shell).copy("test");
+
+        // Assert
+        assertThat(result).isTrue();
+        verify(shell).run("clip", "test");
+    }
+
+    @Test
+    void linux_clipboard_prefers_wl_copy() {
+        // Arrange
+        when(shell.which("wl-copy")).thenReturn(true);
+        when(shell.run("wl-copy", "test")).thenReturn(true);
+
+        // Act
+        var result = new LinuxClipboard(shell).copy("test");
+
+        // Assert
+        assertThat(result).isTrue();
+        verify(shell).run("wl-copy", "test");
+        verify(shell, never()).which("xclip");
+    }
+
+    @Test
+    void linux_clipboard_falls_back_to_xclip() {
+        // Arrange
+        when(shell.which("wl-copy")).thenReturn(false);
+        when(shell.which("xclip")).thenReturn(true);
+        when(shell.run(List.of("xclip", "-selection", "clipboard"), "test")).thenReturn(true);
+
+        // Act
+        var result = new LinuxClipboard(shell).copy("test");
+
+        // Assert
+        assertThat(result).isTrue();
+        verify(shell).run(List.of("xclip", "-selection", "clipboard"), "test");
+    }
+
+    @Test
+    void linux_clipboard_falls_back_to_xsel() {
+        // Arrange
+        when(shell.which("wl-copy")).thenReturn(false);
+        when(shell.which("xclip")).thenReturn(false);
+        when(shell.which("xsel")).thenReturn(true);
+        when(shell.run(List.of("xsel", "--clipboard"), "test")).thenReturn(true);
+
+        // Act
+        var result = new LinuxClipboard(shell).copy("test");
+
+        // Assert
+        assertThat(result).isTrue();
+        verify(shell).run(List.of("xsel", "--clipboard"), "test");
+    }
+
+    @Test
+    void linux_clipboard_returns_false_when_no_supported_tool_is_found() {
+        // Arrange
+        when(shell.which(anyString())).thenReturn(false);
+
+        // Act
+        var result = new LinuxClipboard(shell).copy("test");
+
+        // Assert
+        assertThat(result).isFalse();
+        verify(shell, never()).run(anyList(), anyString());
+    }
+}

--- a/src/test/java/it/mulders/mcs/dagger/ClipboardModuleTest.java
+++ b/src/test/java/it/mulders/mcs/dagger/ClipboardModuleTest.java
@@ -1,0 +1,44 @@
+package it.mulders.mcs.dagger;
+
+import it.mulders.mcs.clipboard.Clipboard;
+import it.mulders.mcs.clipboard.LinuxClipboard;
+import it.mulders.mcs.clipboard.MacClipboard;
+import it.mulders.mcs.clipboard.NoOpClipboard;
+import it.mulders.mcs.clipboard.WindowsClipboard;
+import java.util.stream.Stream;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junitpioneer.jupiter.ClearSystemProperty;
+import org.junitpioneer.jupiter.RestoreSystemProperties;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ClipboardModuleTest implements WithAssertions {
+
+    private static Stream<Arguments> osMapping() {
+        return Stream.of(
+                Arguments.of("Mac OS X", MacClipboard.class),
+                Arguments.of("Windows 10", WindowsClipboard.class),
+                Arguments.of("Linux", LinuxClipboard.class),
+                Arguments.of("FreeBSD", LinuxClipboard.class),
+                Arguments.of("FunOS", NoOpClipboard.class));
+    }
+
+    @ParameterizedTest
+    @MethodSource("osMapping")
+    @RestoreSystemProperties
+    void returns_correct_clipboard_command_for_os(String osName, Class<? extends Clipboard> expectedType) {
+        System.setProperty("os.name", osName);
+        assertThat(ClipboardModule.provideClipboard()).isInstanceOf(expectedType);
+    }
+
+    @Test
+    @ClearSystemProperty(key = "os.name")
+    void returns_noop_clipboard_when_os_name_is_missing() {
+        assertThat(ClipboardModule.provideClipboard()).isInstanceOf(NoOpClipboard.class);
+    }
+}

--- a/src/test/java/it/mulders/mcs/printer/ClipboardOutputPrinterTest.java
+++ b/src/test/java/it/mulders/mcs/printer/ClipboardOutputPrinterTest.java
@@ -1,0 +1,80 @@
+package it.mulders.mcs.printer;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import it.mulders.mcs.clipboard.Clipboard;
+import it.mulders.mcs.search.artifact.SearchQuery;
+import it.mulders.mcs.search.artifact.SearchResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ClipboardOutputPrinterTest implements WithAssertions {
+
+    private static final SearchQuery QUERY =
+            SearchQuery.search("org.codehaus.plexus:plexus-utils:3.4.1").build();
+
+    private static final SearchResponse.Response RESPONSE =
+            new SearchResponse.Response(1, 0, new SearchResponse.Response.Doc[] {
+                new SearchResponse.Response.Doc(
+                        "org.codehaus.plexus:plexus-utils:3.4.1",
+                        "org.codehaus.plexus",
+                        "plexus-utils",
+                        "3.4.1",
+                        null,
+                        "jar",
+                        1630022910000L)
+            });
+
+    private final Clipboard clipboard = mock(Clipboard.class);
+    private final CoordinatePrinter delegate = new GavOutput();
+    private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+    @Test
+    void prints_hint_when_copy_flag_is_false() {
+        // Arrange
+        var printer = new ClipboardOutputPrinter(delegate, clipboard, false);
+
+        // Act
+        printer.print(QUERY, RESPONSE, new PrintStream(buffer));
+
+        // Assert
+        verifyNoInteractions(clipboard);
+        assertThat(buffer.toString()).contains("Pass -c or --copy to copy this snippet to your clipboard");
+    }
+
+    @Test
+    void reports_failure_when_copy_fails() {
+        // Arrange
+        when(clipboard.copy(any())).thenReturn(false);
+        var printer = new ClipboardOutputPrinter(delegate, clipboard, true);
+
+        // Act
+        printer.print(QUERY, RESPONSE, new PrintStream(buffer));
+
+        // Assert
+        assertThat(buffer.toString()).contains("Could not copy to clipboard");
+    }
+
+    @Test
+    void copies_coordinates_and_prints_confirmation() {
+        // Arrange
+        when(clipboard.copy(any())).thenReturn(true);
+        var printer = new ClipboardOutputPrinter(delegate, clipboard, true);
+
+        // Act
+        printer.print(QUERY, RESPONSE, new PrintStream(buffer));
+
+        // Assert
+        verify(clipboard).copy("org.codehaus.plexus:plexus-utils:3.4.1");
+        assertThat(buffer.toString()).contains("Snippet copied to clipboard");
+    }
+}

--- a/src/test/java/it/mulders/mcs/search/SearchCommandHandlerTest.java
+++ b/src/test/java/it/mulders/mcs/search/SearchCommandHandlerTest.java
@@ -4,8 +4,10 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import it.mulders.mcs.clipboard.Clipboard;
 import it.mulders.mcs.common.Result;
 import it.mulders.mcs.printer.OutputFactory;
 import it.mulders.mcs.printer.OutputPrinter;
@@ -25,6 +27,7 @@ import org.junit.jupiter.api.Test;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class SearchCommandHandlerTest implements WithAssertions {
+    private final Clipboard clipboard = mock(Clipboard.class);
     private final ComponentReportClient componentReportClient = mock(ComponentReportClient.class);
     private final OutputPrinter outputPrinter = mock(OutputPrinter.class);
     private final OutputFactory outputFactory = new OutputFactory() {
@@ -90,7 +93,7 @@ class SearchCommandHandlerTest implements WithAssertions {
     ;
 
     private final SearchCommandHandler handler =
-            new SearchCommandHandler(componentReportClient, outputFactory, searchClient);
+            new SearchCommandHandler(clipboard, componentReportClient, outputFactory, searchClient);
 
     @Nested
     @DisplayName("Wildcard search")
@@ -102,7 +105,7 @@ class SearchCommandHandlerTest implements WithAssertions {
                     .thenReturn(new Result.Success<>(new SearchResponse(singleArtifactResponse)));
 
             // Act
-            handler.search(SearchQuery.search("plexus-utils").build(), "maven", false);
+            handler.search(SearchQuery.search("plexus-utils").build(), "maven", false, false);
 
             // Assert
             verify(outputPrinter).print(any(WildcardSearchQuery.class), eq(singleArtifactResponse), any());
@@ -117,7 +120,7 @@ class SearchCommandHandlerTest implements WithAssertions {
             when(searchClient.search(any())).thenReturn(result);
 
             assertThatThrownBy(
-                            () -> handler.search(SearchQuery.search("tls-error").build(), "maven", false))
+                            () -> handler.search(SearchQuery.search("tls-error").build(), "maven", false, false))
                     .isInstanceOf(RuntimeException.class);
         }
     }
@@ -130,11 +133,11 @@ class SearchCommandHandlerTest implements WithAssertions {
             // Arrange
             when(searchClient.search(any()))
                     .thenReturn(new Result.Success<>(new SearchResponse(singleArtifactResponse)));
-            var handler = new SearchCommandHandler(componentReportClient, outputFactory, searchClient);
+            var handler = new SearchCommandHandler(clipboard, componentReportClient, outputFactory, searchClient);
             var query = SearchQuery.search("org.codehaus.plexus:plexus-utils").build();
 
             // Act
-            handler.search(query, "maven", false);
+            handler.search(query, "maven", false, false);
 
             // Assert
             verify(outputPrinter).print(eq(query), eq(singleArtifactResponse), any());
@@ -145,11 +148,11 @@ class SearchCommandHandlerTest implements WithAssertions {
             // Arrange
             when(searchClient.search(any()))
                     .thenReturn(new Result.Success<>(new SearchResponse(singleArtifactResponse)));
-            var handler = new SearchCommandHandler(componentReportClient, outputFactory, searchClient);
+            var handler = new SearchCommandHandler(clipboard, componentReportClient, outputFactory, searchClient);
 
             // Act
             handler.search(
-                    SearchQuery.search("org.codehaus.plexus:plexus-utils").build(), "maven", false);
+                    SearchQuery.search("org.codehaus.plexus:plexus-utils").build(), "maven", false, false);
 
             // Assert
             verify(outputPrinter).print(any(CoordinateQuery.class), eq(singleArtifactResponse), any());
@@ -161,8 +164,41 @@ class SearchCommandHandlerTest implements WithAssertions {
                             SearchQuery.search("org.codehaus.plexus:tls-error:3.4.1")
                                     .build(),
                             "maven",
+                            false,
                             false))
                     .isInstanceOf(RuntimeException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Clipboard Copy")
+    class ClipboardCopyTest {
+        @Test
+        void should_not_invoke_clipboard_when_flag_disabled() {
+            // Arrange
+            when(searchClient.search(any()))
+                    .thenReturn(new Result.Success<>(new SearchResponse(singleArtifactResponse)));
+            var query = SearchQuery.search("org.codehaus.plexus:plexus-utils").build();
+
+            // Act
+            handler.search(query, "gav", false, false);
+
+            // Assert
+            verifyNoInteractions(clipboard);
+        }
+
+        @Test
+        void should_not_invoke_clipboard_when_multiple_artifact_response() {
+            // Arrange
+            when(searchClient.search(any()))
+                    .thenReturn(new Result.Success<>(new SearchResponse(multipleArtifactResponse)));
+            var query = SearchQuery.search("org.codehaus.plexus:plexus-utils").build();
+
+            // Act
+            handler.search(query, "gav", false, true);
+
+            // Assert
+            verifyNoInteractions(clipboard);
         }
     }
 }


### PR DESCRIPTION
An alternative approach to the clipboard feature approved in #184. 

**Similarities**
- Opt-in only by design e.g. Must pass the `--copy` flag.
- Prints a hint when a single coordinate is returned, and the flag isn't used. 
- Prints confirmation when snippet is copied to clipboard.

**Differences**
- Instead of `AWT` this approach uses OS native clipboard utilities (work-a-round to GraalVM native build issues).
- Uses a new `ClipboardOutputPrinter` that acts as a decorator.